### PR TITLE
webkaos.conf: added whitespace to prevent fields concatenating.

### DIFF
--- a/SOURCES/webkaos.conf
+++ b/SOURCES/webkaos.conf
@@ -47,20 +47,20 @@ http {
                        '$status $body_bytes_sent '
                        '"$http_x_forwarded_for" "$http_referer"  $host '
                        '$request_time $upstream_response_time '
-                       '$upstream_addr - $upstream_status ';
+                       '$upstream_addr - $upstream_status';
 
   log_format reflog '$remote_addr - $remote_user [$time_local] '
                     '"$request" $status $bytes_sent '
-                    '"$http_referer" "$http_user_agent" ';
+                    '"$http_referer" "$http_user_agent"';
 
-  log_format timed_combined '$remote_addr - $remote_user [$time_local]  '
+  log_format timed_combined '$remote_addr - $remote_user [$time_local] '
                             '"$request" $status $body_bytes_sent '
-                            '"$http_x_forwarded_for" "$http_referer"  $host'
+                            '"$http_x_forwarded_for" "$http_referer" $host '
                             '"$http_referer" "$http_user_agent" '
                             '$request_time $upstream_response_time';
 
   log_format vhost_ip_full_format '$remote_addr - $remote_user [$time_local] $host $server_addr $request '
-                                  '$status $body_bytes_sent "$http_referer"'
+                                  '$status $body_bytes_sent "$http_referer" '
                                   '"$http_user_agent" "$http_x_forwarded_for" $request_time-$upstream_response_time';
 
   access_log  /var/log/webkaos/access.log  main;


### PR DESCRIPTION
I read access logs and found that some of log formats haven't whitespace between fields. This PR should fix this unnecessary behaviour of concatenating data.