### PR TITLE
webkaos: updated to 1.11.4.

### DIFF
--- a/SOURCES/webkaos.patch
+++ b/SOURCES/webkaos.patch
@@ -1,6 +1,6 @@
-diff -urN nginx-1.11.3-orig/auto/lib/openssl/make nginx-1.11.3/auto/lib/openssl/make
---- nginx-1.11.3-orig/auto/lib/openssl/make	2016-07-12 18:27:54.827769832 -0400
-+++ nginx-1.11.3/auto/lib/openssl/make	2016-07-12 18:54:29.616445352 -0400
+diff -urN nginx-1.11.4-orig/auto/lib/openssl/make nginx-1.11.4/auto/lib/openssl/make
+--- nginx-1.11.4-orig/auto/lib/openssl/make	2016-09-23 18:27:54.827769832 -0400
++++ nginx-1.11.4/auto/lib/openssl/make	2016-09-23 18:54:29.616445352 -0400
 @@ -45,18 +45,18 @@
              /*) ngx_prefix="$OPENSSL/.openssl" ;;
              *)  ngx_prefix="$PWD/$OPENSSL/.openssl" ;;
@@ -24,9 +24,9 @@ diff -urN nginx-1.11.3-orig/auto/lib/openssl/make nginx-1.11.3/auto/lib/openssl/
      ;;
  
  esac
-diff -urN nginx-1.11.3-orig/src/core/nginx.c nginx-1.11.3/src/core/nginx.c
---- nginx-1.11.3-orig/src/core/nginx.c	2016-07-12 18:27:54.864769825 -0400
-+++ nginx-1.11.3/src/core/nginx.c	2016-07-12 18:55:27.651473539 -0400
+diff -urN nginx-1.11.4-orig/src/core/nginx.c nginx-1.11.4/src/core/nginx.c
+--- nginx-1.11.4-orig/src/core/nginx.c	2016-09-23 18:27:54.864769825 -0400
++++ nginx-1.11.4/src/core/nginx.c	2016-09-23 18:55:27.651473539 -0400
 @@ -378,9 +378,9 @@
  
      if (ngx_show_help) {
@@ -40,13 +40,12 @@ diff -urN nginx-1.11.3-orig/src/core/nginx.c nginx-1.11.3/src/core/nginx.c
              "Options:" NGX_LINEFEED
              "  -?,-h         : this help" NGX_LINEFEED
              "  -v            : show version and exit" NGX_LINEFEED
-diff -urN nginx-1.11.3-orig/src/core/nginx.h nginx-1.11.3/src/core/nginx.h
---- nginx-1.11.3-orig/src/core/nginx.h	2016-07-12 18:27:54.868769825 -0400
-+++ nginx-1.11.3/src/core/nginx.h	2016-07-12 18:55:41.000000000 -0400
+--- nginx-1.11.4-orig/src/core/nginx.h	2016-09-23 18:27:54.868769825 -0400
++++ nginx-1.11.4/src/core/nginx.h	2016-09-23 18:55:41.000000000 -0400
 @@ -11,7 +11,7 @@
  
- #define nginx_version      1011003
- #define NGINX_VERSION      "1.11.3"
+ #define nginx_version      1011004
+ #define NGINX_VERSION      "1.11.4"
 -#define NGINX_VER          "nginx/" NGINX_VERSION
 +#define NGINX_VER          "webkaos/" NGINX_VERSION
  
@@ -61,9 +60,9 @@ diff -urN nginx-1.11.3-orig/src/core/nginx.h nginx-1.11.3/src/core/nginx.h
  #define NGX_OLDPID_EXT     ".oldbin"
  
  
-diff -urN nginx-1.11.3-orig/src/core/ngx_log.c nginx-1.11.3/src/core/ngx_log.c
---- nginx-1.11.3-orig/src/core/ngx_log.c	2016-07-12 18:27:54.867769824 -0400
-+++ nginx-1.11.3/src/core/ngx_log.c	2016-07-12 18:57:00.359519372 -0400
+diff -urN nginx-1.11.4-orig/src/core/ngx_log.c nginx-1.11.4/src/core/ngx_log.c
+--- nginx-1.11.4-orig/src/core/ngx_log.c	2016-09-23 18:27:54.867769824 -0400
++++ nginx-1.11.4/src/core/ngx_log.c	2016-09-23 18:57:00.359519372 -0400
 @@ -202,9 +202,9 @@
          return;
      }
@@ -94,9 +93,9 @@ diff -urN nginx-1.11.3-orig/src/core/ngx_log.c nginx-1.11.3/src/core/ngx_log.c
          return NGX_CONF_ERROR;
  #endif
  
-diff -urN nginx-1.11.3-orig/src/http/modules/ngx_http_autoindex_module.c nginx-1.11.3/src/http/modules/ngx_http_autoindex_module.c
---- nginx-1.11.3-orig/src/http/modules/ngx_http_autoindex_module.c	2016-07-12 18:27:54.850769821 -0400
-+++ nginx-1.11.3/src/http/modules/ngx_http_autoindex_module.c	2016-07-12 18:57:24.517531092 -0400
+diff -urN nginx-1.11.4-orig/src/http/modules/ngx_http_autoindex_module.c nginx-1.11.4/src/http/modules/ngx_http_autoindex_module.c
+--- nginx-1.11.4-orig/src/http/modules/ngx_http_autoindex_module.c	2016-09-23 18:27:54.850769821 -0400
++++ nginx-1.11.4/src/http/modules/ngx_http_autoindex_module.c	2016-09-23 18:57:24.517531092 -0400
 @@ -445,9 +445,11 @@
      ;
  
@@ -172,9 +171,9 @@ diff -urN nginx-1.11.3-orig/src/http/modules/ngx_http_autoindex_module.c nginx-1
                                tm.ngx_tm_mday,
                                months[tm.ngx_tm_mon - 1],
                                tm.ngx_tm_year,
-diff -urN nginx-1.11.3-orig/src/http/ngx_http_header_filter_module.c nginx-1.11.3/src/http/ngx_http_header_filter_module.c
---- nginx-1.11.3-orig/src/http/ngx_http_header_filter_module.c	2016-07-12 18:27:54.855769823 -0400
-+++ nginx-1.11.3/src/http/ngx_http_header_filter_module.c	2016-07-12 19:01:30.000000000 -0400
+diff -urN nginx-1.11.4-orig/src/http/ngx_http_header_filter_module.c nginx-1.11.4/src/http/ngx_http_header_filter_module.c
+--- nginx-1.11.4-orig/src/http/ngx_http_header_filter_module.c	2016-09-23 18:27:54.855769823 -0400
++++ nginx-1.11.4/src/http/ngx_http_header_filter_module.c	2016-09-23 19:01:30.000000000 -0400
 @@ -46,7 +46,7 @@
  };
  
@@ -228,9 +227,9 @@ diff -urN nginx-1.11.3-orig/src/http/ngx_http_header_filter_module.c nginx-1.11.
  #define NGX_HTTP_OFF_5XX   (NGX_HTTP_LAST_4XX - 400 + NGX_HTTP_OFF_4XX)
  
      ngx_string("500 Internal Server Error"),
-diff -urN nginx-1.11.3-orig/src/http/ngx_http_special_response.c nginx-1.11.3/src/http/ngx_http_special_response.c
---- nginx-1.11.3-orig/src/http/ngx_http_special_response.c	2016-07-12 18:27:54.857769823 -0400
-+++ nginx-1.11.3/src/http/ngx_http_special_response.c	2016-07-12 18:57:48.265543888 -0400
+diff -urN nginx-1.11.4-orig/src/http/ngx_http_special_response.c nginx-1.11.4/src/http/ngx_http_special_response.c
+--- nginx-1.11.4-orig/src/http/ngx_http_special_response.c	2016-09-23 18:27:54.857769823 -0400
++++ nginx-1.11.4/src/http/ngx_http_special_response.c	2016-09-23 18:57:48.265543888 -0400
 @@ -19,14 +19,14 @@
  
  
@@ -683,9 +682,9 @@ diff -urN nginx-1.11.3-orig/src/http/ngx_http_special_response.c nginx-1.11.3/sr
  #define NGX_HTTP_OFF_5XX   (NGX_HTTP_LAST_4XX - 400 + NGX_HTTP_OFF_4XX)
  
      ngx_string(ngx_http_error_494_page), /* 494, request header too large */
-diff -urN nginx-1.11.3-orig/src/http/v2/ngx_http_v2_filter_module.c nginx-1.11.3/src/http/v2/ngx_http_v2_filter_module.c
---- nginx-1.11.3-orig/src/http/v2/ngx_http_v2_filter_module.c	2016-07-12 18:27:54.860769824 -0400
-+++ nginx-1.11.3/src/http/v2/ngx_http_v2_filter_module.c	2016-07-12 19:03:04.000000000 -0400
+diff -urN nginx-1.11.4-orig/src/http/v2/ngx_http_v2_filter_module.c nginx-1.11.4/src/http/v2/ngx_http_v2_filter_module.c
+--- nginx-1.11.4-orig/src/http/v2/ngx_http_v2_filter_module.c	2016-09-23 18:27:54.860769824 -0400
++++ nginx-1.11.4/src/http/v2/ngx_http_v2_filter_module.c	2016-09-23 19:03:04.000000000 -0400
 @@ -139,7 +139,7 @@
      ngx_http_core_srv_conf_t  *cscf;
      u_char                     addr[NGX_SOCKADDR_STRLEN];
@@ -704,9 +703,9 @@ diff -urN nginx-1.11.3-orig/src/http/v2/ngx_http_v2_filter_module.c nginx-1.11.3
  
          *pos++ = ngx_http_v2_inc_indexed(NGX_HTTP_V2_SERVER_INDEX);
  
-diff -urN nginx-1.11.3-orig/src/os/unix/ngx_setproctitle.c nginx-1.11.3/src/os/unix/ngx_setproctitle.c
---- nginx-1.11.3-orig/src/os/unix/ngx_setproctitle.c	2016-07-12 18:27:54.836769823 -0400
-+++ nginx-1.11.3/src/os/unix/ngx_setproctitle.c	2016-07-12 18:58:12.202554002 -0400
+diff -urN nginx-1.11.4-orig/src/os/unix/ngx_setproctitle.c nginx-1.11.4/src/os/unix/ngx_setproctitle.c
+--- nginx-1.11.4-orig/src/os/unix/ngx_setproctitle.c	2016-09-23 18:27:54.836769823 -0400
++++ nginx-1.11.4/src/os/unix/ngx_setproctitle.c	2016-09-23 18:58:12.202554002 -0400
 @@ -89,7 +89,7 @@
  
      ngx_os_argv[1] = NULL;

--- a/webkaos-centos6.spec
+++ b/webkaos-centos6.spec
@@ -43,10 +43,10 @@
 %define service_name         %{name}
 %define service_home         %{_cachedir}/%{service_name}
 
-%define open_ssl_ver         1.0.2h
-%define psol_ver             1.11.33.2
-%define lua_module_ver       0.10.5
-%define mh_module_ver        0.30
+%define open_ssl_ver         1.0.2i
+%define psol_ver             1.11.33.4
+%define lua_module_ver       0.10.6
+%define mh_module_ver        0.31
 %define pcre_ver             8.39
 %define zlib_ver             1.2.8
 
@@ -58,8 +58,8 @@
 
 Summary:              Superb high performance web server
 Name:                 webkaos
-Version:              1.11.3
-Release:              1%{?dist}
+Version:              1.11.4
+Release:              0%{?dist}
 License:              2-clause BSD-like license
 Group:                System Environment/Daemons
 Vendor:               Nginx / Google / CloudFlare / ESSENTIALKAOS
@@ -170,7 +170,6 @@ Links for nginx compatibility.
 %{__mv} ngx_pagespeed-%{pagespeed_fullver}/README.md  ./PAGESPEED-README.md
 
 %{__mv} lua-nginx-module-%{lua_module_ver}/README.markdown ./LUAMODULE-README.markdown
-%{__mv} lua-nginx-module-%{lua_module_ver}/Changes         ./LUAMODULE-CHANGES
 
 %{__mv} headers-more-nginx-module-%{mh_module_ver}/README.markdown ./HEADERSMORE-README.markdown
 
@@ -413,7 +412,7 @@ fi
 %defattr(-,root,root)
 %doc NGINX-CHANGES NGINX-CHANGES.ru NGINX-LICENSE NGINX-README
 %doc PAGESPEED-LICENSE PAGESPEED-README.md
-%doc LUAMODULE-README.markdown LUAMODULE-CHANGES
+%doc LUAMODULE-README.markdown
 %doc HEADERSMORE-README.markdown
 
 %{_sbindir}/%{name}
@@ -468,6 +467,13 @@ fi
 ###############################################################################
 
 %changelog
+* Fri Sep 23 2016 Gleb Goncharov <g.goncharov@fun-box.ru> - 1.11.4-0
+- Nginx updated to 1.11.4
+- OpenSSL updated to 1.0.2i
+- PageSpeed updated to 1.11.33.4
+- Lua module updated to 0.10.6
+- More Headers module updated to 0.31
+
 * Fri Aug 19 2016 Anton Novojilov <andy@essentialkaos.com> - 1.11.3-1
 - Fixed bug with log format
 

--- a/webkaos-centos7.spec
+++ b/webkaos-centos7.spec
@@ -43,10 +43,10 @@
 %define service_name         %{name}
 %define service_home         %{_cachedir}/%{service_name}
 
-%define open_ssl_ver         1.0.2h
-%define psol_ver             1.11.33.2
-%define lua_module_ver       0.10.5
-%define mh_module_ver        0.30
+%define open_ssl_ver         1.0.2i
+%define psol_ver             1.11.33.4
+%define lua_module_ver       0.10.6
+%define mh_module_ver        0.31
 %define pcre_ver             8.39
 %define zlib_ver             1.2.8
 
@@ -58,8 +58,8 @@
 
 Summary:              Superb high performance web server
 Name:                 webkaos
-Version:              1.11.3
-Release:              1%{?dist}
+Version:              1.11.4
+Release:              0%{?dist}
 License:              2-clause BSD-like license
 Group:                System Environment/Daemons
 Vendor:               Nginx / Google / CloudFlare / ESSENTIALKAOS
@@ -169,7 +169,6 @@ Links for nginx compatibility.
 %{__mv} ngx_pagespeed-%{pagespeed_fullver}/README.md  ./PAGESPEED-README.md
 
 %{__mv} lua-nginx-module-%{lua_module_ver}/README.markdown ./LUAMODULE-README.markdown
-%{__mv} lua-nginx-module-%{lua_module_ver}/Changes         ./LUAMODULE-CHANGES
 
 %{__mv} headers-more-nginx-module-%{mh_module_ver}/README.markdown ./HEADERSMORE-README.markdown
 
@@ -409,7 +408,7 @@ fi
 %defattr(-,root,root)
 %doc NGINX-CHANGES NGINX-CHANGES.ru NGINX-LICENSE NGINX-README
 %doc PAGESPEED-LICENSE PAGESPEED-README.md
-%doc LUAMODULE-README.markdown LUAMODULE-CHANGES
+%doc LUAMODULE-README.markdown
 %doc HEADERSMORE-README.markdown
 
 %{_sbindir}/%{name}
@@ -464,6 +463,13 @@ fi
 ###############################################################################
 
 %changelog
+* Fri Sep 23 2016 Gleb Goncharov <g.goncharov@fun-box.ru> - 1.11.4-0
+- Nginx updated to 1.11.4
+- OpenSSL updated to 1.0.2i
+- PageSpeed updated to 1.11.33.4
+- Lua module updated to 0.10.6
+- More Headers module updated to 0.31
+
 * Fri Aug 19 2016 Anton Novojilov <andy@essentialkaos.com> - 1.11.3-1
 - Fixed bug with log format
 


### PR DESCRIPTION
### Changelog

- Nginx updated to 1.11.4
- OpenSSL updated to 1.0.2i
- PageSpeed updated to 1.11.33.4
- Lua module updated to 0.10.6
- More Headers module updated to 0.31