### PR TITLE
webkaos: added X-Request-ID

### DIFF
--- a/SOURCES/webkaos.conf
+++ b/SOURCES/webkaos.conf
@@ -39,31 +39,31 @@ http {
   include       /etc/webkaos/mime.types;
   default_type  application/octet-stream;
 
-  log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-                    '$status $body_bytes_sent "$http_referer" '
-                    '"$http_user_agent" "$http_x_forwarded_for"';
+  log_format main '[$request_id] $remote_addr - $remote_user [$time_local] "$request" '
+                  '$status $body_bytes_sent "$http_referer" '
+                  '"$http_user_agent" "$http_x_forwarded_for"';
 
-  log_format extended  '$remote_addr - [$time_local] "$request" '
-                       '$status $body_bytes_sent '
-                       '"$http_x_forwarded_for" "$http_referer"  $host '
-                       '$request_time $upstream_response_time '
-                       '$upstream_addr - $upstream_status';
+  log_format extended '[$request_id] $remote_addr - [$time_local] "$request" '
+                      '$status $body_bytes_sent '
+                      '"$http_x_forwarded_for" "$http_referer" $host '
+                      '$request_time $upstream_response_time '
+                      '$upstream_addr - $upstream_status';
 
-  log_format reflog '$remote_addr - $remote_user [$time_local] '
+  log_format reflog '[$request_id] $remote_addr - $remote_user [$time_local] '
                     '"$request" $status $bytes_sent '
                     '"$http_referer" "$http_user_agent"';
 
-  log_format timed_combined '$remote_addr - $remote_user [$time_local] '
+  log_format timed_combined '[$request_id] $remote_addr - $remote_user [$time_local] '
                             '"$request" $status $body_bytes_sent '
                             '"$http_x_forwarded_for" "$http_referer" $host '
                             '"$http_referer" "$http_user_agent" '
                             '$request_time $upstream_response_time';
 
-  log_format vhost_ip_full_format '$remote_addr - $remote_user [$time_local] $host $server_addr $request '
+  log_format vhost_ip_full_format '[$request_id] $remote_addr - $remote_user [$time_local] $host $server_addr $request '
                                   '$status $body_bytes_sent "$http_referer" '
-                                  '"$http_user_agent" "$http_x_forwarded_for" $request_time-$upstream_response_time';
+                                  '"$http_user_agent" "$http_x_forwarded_for" $request_time $upstream_response_time';
 
-  access_log  /var/log/webkaos/access.log  main;
+  access_log /var/log/webkaos/access.log main;
 
   sendfile              on;
   tcp_nopush            on;
@@ -120,6 +120,11 @@ http {
   ssl_stapling_verify        on;
   resolver                   8.8.4.4 8.8.8.8 valid=300s;
   resolver_timeout           10s;
+
+  ##############################################################################
+
+  # Header with unique request identifier.
+  add_header X-Request-ID "$request_id";
 
   ##############################################################################
   


### PR DESCRIPTION
I suggest to set a global unique identifier `$request_id` (was introduced at nginx 1.11.0), which might be possible to tell to your application. I find it very useful for debugging accidents and logging events. 