### PR TITLE
Version 1.13.7

### DIFF
--- a/SOURCES/boringssl-tls13-support.patch
+++ b/SOURCES/boringssl-tls13-support.patch
@@ -1,19 +1,19 @@
 diff -urN boringssl-orig/ssl/s3_lib.cc boringssl/ssl/s3_lib.cc
---- boringssl-orig/ssl/s3_lib.cc	2017-10-14 00:05:58.000000000 +0200
-+++ boringssl/ssl/s3_lib.cc	2017-10-17 23:21:59.187526554 +0200
-@@ -194,7 +194,7 @@
+--- boringssl-orig/ssl/s3_lib.cc	2017-11-27 23:19:17.297484878 +0100
++++ boringssl/ssl/s3_lib.cc	2017-11-27 23:20:24.000000000 +0100
+@@ -199,7 +199,7 @@
    // TODO(davidben): Move this field into |s3|, have it store the normalized
    // protocol version, and implement this pre-negotiation quirk in |SSL_version|
    // at the API boundary rather than in internal state.
 -  ssl->version = TLS1_2_VERSION;
 +  ssl->version = TLS1_3_VERSION;
-   return 1;
+   return true;
  }
  
 diff -urN boringssl-orig/ssl/ssl_versions.cc boringssl/ssl/ssl_versions.cc
---- boringssl-orig/ssl/ssl_versions.cc	2017-10-14 00:05:58.000000000 +0200
-+++ boringssl/ssl/ssl_versions.cc	2017-10-18 00:45:56.000000000 +0200
-@@ -199,7 +199,7 @@
+--- boringssl-orig/ssl/ssl_versions.cc	2017-11-27 23:19:17.294484878 +0100
++++ boringssl/ssl/ssl_versions.cc	2017-11-27 23:21:15.000000000 +0100
+@@ -209,7 +209,7 @@
                              uint16_t version) {
    // Zero is interpreted as the default maximum version.
    if (version == 0) {

--- a/SOURCES/webkaos.patch
+++ b/SOURCES/webkaos.patch
@@ -1,6 +1,6 @@
-diff -urN nginx-1.13.6-orig/auto/lib/openssl/make nginx-1.13.6/auto/lib/openssl/make
---- nginx-1.13.6-orig/auto/lib/openssl/make	2017-10-10 17:22:51.000000000 +0200
-+++ nginx-1.13.6/auto/lib/openssl/make	2017-10-13 23:48:34.072611151 +0200
+diff -urN nginx-1.13.7-orig/auto/lib/openssl/make nginx-1.13.7/auto/lib/openssl/make
+--- nginx-1.13.7-orig/auto/lib/openssl/make	2017-11-27 23:04:57.710526238 +0100
++++ nginx-1.13.7/auto/lib/openssl/make	2017-11-27 23:07:50.246505745 +0100
 @@ -45,18 +45,18 @@
              /*) ngx_prefix="$OPENSSL/.openssl" ;;
              *)  ngx_prefix="$PWD/$OPENSSL/.openssl" ;;
@@ -24,9 +24,9 @@ diff -urN nginx-1.13.6-orig/auto/lib/openssl/make nginx-1.13.6/auto/lib/openssl/
      ;;
  
  esac
-diff -urN nginx-1.13.6-orig/src/core/nginx.c nginx-1.13.6/src/core/nginx.c
---- nginx-1.13.6-orig/src/core/nginx.c	2017-10-10 17:22:51.000000000 +0200
-+++ nginx-1.13.6/src/core/nginx.c	2017-10-13 23:48:34.093611455 +0200
+diff -urN nginx-1.13.7-orig/src/core/nginx.c nginx-1.13.7/src/core/nginx.c
+--- nginx-1.13.7-orig/src/core/nginx.c	2017-11-27 23:04:57.743525843 +0100
++++ nginx-1.13.7/src/core/nginx.c	2017-11-27 23:07:50.266506656 +0100
 @@ -388,13 +388,13 @@
  static void
  ngx_show_version_info(void)
@@ -45,13 +45,13 @@ diff -urN nginx-1.13.6-orig/src/core/nginx.c nginx-1.13.6/src/core/nginx.c
              "Options:" NGX_LINEFEED
              "  -?,-h         : this help" NGX_LINEFEED
              "  -v            : show version and exit" NGX_LINEFEED
-diff -urN nginx-1.13.6-orig/src/core/nginx.h nginx-1.13.6/src/core/nginx.h
---- nginx-1.13.6-orig/src/core/nginx.h	2017-10-10 17:22:51.000000000 +0200
-+++ nginx-1.13.6/src/core/nginx.h	2017-10-13 23:52:02.000000000 +0200
+diff -urN nginx-1.13.7-orig/src/core/nginx.h nginx-1.13.7/src/core/nginx.h
+--- nginx-1.13.7-orig/src/core/nginx.h	2017-11-27 23:04:57.745525842 +0100
++++ nginx-1.13.7/src/core/nginx.h	2017-11-27 23:05:31.000000000 +0100
 @@ -11,7 +11,7 @@
  
- #define nginx_version      1013006
- #define NGINX_VERSION      "1.13.6"
+ #define nginx_version      1013007
+ #define NGINX_VERSION      "1.13.7"
 -#define NGINX_VER          "nginx/" NGINX_VERSION
 +#define NGINX_VER          "webkaos/" NGINX_VERSION
  
@@ -66,9 +66,9 @@ diff -urN nginx-1.13.6-orig/src/core/nginx.h nginx-1.13.6/src/core/nginx.h
  #define NGX_OLDPID_EXT     ".oldbin"
  
  
-diff -urN nginx-1.13.6-orig/src/core/ngx_log.c nginx-1.13.6/src/core/ngx_log.c
---- nginx-1.13.6-orig/src/core/ngx_log.c	2017-10-10 17:22:51.000000000 +0200
-+++ nginx-1.13.6/src/core/ngx_log.c	2017-10-13 23:48:34.117611464 +0200
+diff -urN nginx-1.13.7-orig/src/core/ngx_log.c nginx-1.13.7/src/core/ngx_log.c
+--- nginx-1.13.7-orig/src/core/ngx_log.c	2017-11-27 23:04:57.744525843 +0100
++++ nginx-1.13.7/src/core/ngx_log.c	2017-11-27 23:07:50.292507154 +0100
 @@ -202,9 +202,9 @@
          return;
      }
@@ -99,9 +99,9 @@ diff -urN nginx-1.13.6-orig/src/core/ngx_log.c nginx-1.13.6/src/core/ngx_log.c
          return NGX_CONF_ERROR;
  #endif
  
-diff -urN nginx-1.13.6-orig/src/http/modules/ngx_http_autoindex_module.c nginx-1.13.6/src/http/modules/ngx_http_autoindex_module.c
---- nginx-1.13.6-orig/src/http/modules/ngx_http_autoindex_module.c	2017-10-10 17:22:52.000000000 +0200
-+++ nginx-1.13.6/src/http/modules/ngx_http_autoindex_module.c	2017-10-13 23:48:34.132611467 +0200
+diff -urN nginx-1.13.7-orig/src/http/modules/ngx_http_autoindex_module.c nginx-1.13.7/src/http/modules/ngx_http_autoindex_module.c
+--- nginx-1.13.7-orig/src/http/modules/ngx_http_autoindex_module.c	2017-11-27 23:04:57.732525833 +0100
++++ nginx-1.13.7/src/http/modules/ngx_http_autoindex_module.c	2017-11-27 23:07:50.308507152 +0100
 @@ -445,9 +445,11 @@
      ;
  
@@ -177,9 +177,9 @@ diff -urN nginx-1.13.6-orig/src/http/modules/ngx_http_autoindex_module.c nginx-1
                                tm.ngx_tm_mday,
                                months[tm.ngx_tm_mon - 1],
                                tm.ngx_tm_year,
-diff -urN nginx-1.13.6-orig/src/http/ngx_http_header_filter_module.c nginx-1.13.6/src/http/ngx_http_header_filter_module.c
---- nginx-1.13.6-orig/src/http/ngx_http_header_filter_module.c	2017-10-10 17:22:52.000000000 +0200
-+++ nginx-1.13.6/src/http/ngx_http_header_filter_module.c	2017-10-13 23:48:34.147611471 +0200
+diff -urN nginx-1.13.7-orig/src/http/ngx_http_header_filter_module.c nginx-1.13.7/src/http/ngx_http_header_filter_module.c
+--- nginx-1.13.7-orig/src/http/ngx_http_header_filter_module.c	2017-11-27 23:04:57.737525851 +0100
++++ nginx-1.13.7/src/http/ngx_http_header_filter_module.c	2017-11-27 23:07:50.322507152 +0100
 @@ -46,7 +46,7 @@
  };
  
@@ -230,9 +230,9 @@ diff -urN nginx-1.13.6-orig/src/http/ngx_http_header_filter_module.c nginx-1.13.
  #define NGX_HTTP_OFF_5XX   (NGX_HTTP_LAST_4XX - 400 + NGX_HTTP_OFF_4XX)
  
      ngx_string("500 Internal Server Error"),
-diff -urN nginx-1.13.6-orig/src/http/ngx_http_special_response.c nginx-1.13.6/src/http/ngx_http_special_response.c
---- nginx-1.13.6-orig/src/http/ngx_http_special_response.c	2017-10-10 17:22:52.000000000 +0200
-+++ nginx-1.13.6/src/http/ngx_http_special_response.c	2017-10-13 23:48:34.165611472 +0200
+diff -urN nginx-1.13.7-orig/src/http/ngx_http_special_response.c nginx-1.13.7/src/http/ngx_http_special_response.c
+--- nginx-1.13.7-orig/src/http/ngx_http_special_response.c	2017-11-27 23:04:57.738525848 +0100
++++ nginx-1.13.7/src/http/ngx_http_special_response.c	2017-11-27 23:07:50.337507151 +0100
 @@ -19,21 +19,21 @@
  
  
@@ -739,9 +739,9 @@ diff -urN nginx-1.13.6-orig/src/http/ngx_http_special_response.c nginx-1.13.6/sr
  #define NGX_HTTP_OFF_5XX   (NGX_HTTP_LAST_4XX - 400 + NGX_HTTP_OFF_4XX)
  
      ngx_string(ngx_http_error_494_page), /* 494, request header too large */
-diff -urN nginx-1.13.6-orig/src/http/v2/ngx_http_v2_filter_module.c nginx-1.13.6/src/http/v2/ngx_http_v2_filter_module.c
---- nginx-1.13.6-orig/src/http/v2/ngx_http_v2_filter_module.c	2017-10-10 17:22:52.000000000 +0200
-+++ nginx-1.13.6/src/http/v2/ngx_http_v2_filter_module.c	2017-10-13 23:51:36.000000000 +0200
+diff -urN nginx-1.13.7-orig/src/http/v2/ngx_http_v2_filter_module.c nginx-1.13.7/src/http/v2/ngx_http_v2_filter_module.c
+--- nginx-1.13.7-orig/src/http/v2/ngx_http_v2_filter_module.c	2017-11-27 23:04:57.739525844 +0100
++++ nginx-1.13.7/src/http/v2/ngx_http_v2_filter_module.c	2017-11-27 23:07:24.000000000 +0100
 @@ -144,7 +144,7 @@
      ngx_http_core_srv_conf_t  *cscf;
      u_char                     addr[NGX_SOCKADDR_STRLEN];
@@ -760,9 +760,9 @@ diff -urN nginx-1.13.6-orig/src/http/v2/ngx_http_v2_filter_module.c nginx-1.13.6
          }
  
          *pos++ = ngx_http_v2_inc_indexed(NGX_HTTP_V2_SERVER_INDEX);
-diff -urN nginx-1.13.6-orig/src/os/unix/ngx_setproctitle.c nginx-1.13.6/src/os/unix/ngx_setproctitle.c
---- nginx-1.13.6-orig/src/os/unix/ngx_setproctitle.c	2017-10-10 17:22:52.000000000 +0200
-+++ nginx-1.13.6/src/os/unix/ngx_setproctitle.c	2017-10-13 23:48:34.187611480 +0200
+diff -urN nginx-1.13.7-orig/src/os/unix/ngx_setproctitle.c nginx-1.13.7/src/os/unix/ngx_setproctitle.c
+--- nginx-1.13.7-orig/src/os/unix/ngx_setproctitle.c	2017-11-27 23:04:57.719526031 +0100
++++ nginx-1.13.7/src/os/unix/ngx_setproctitle.c	2017-11-27 23:07:50.361507151 +0100
 @@ -89,7 +89,7 @@
  
      ngx_os_argv[1] = NULL;

--- a/patch-proc.sh
+++ b/patch-proc.sh
@@ -54,6 +54,16 @@ check() {
   old_ver_dir="${data_dir}/nginx-${old_ver}-orig"
   new_ver_dir="${data_dir}/nginx-${new_ver}-orig"
 
+  if [[ ! -e "$old_ver_dir" ]] ; then
+    show "Directory $old_ver_dir doesn't exist" $RED
+    exit 1
+  fi
+
+  if [[ ! -e "$new_ver_dir" ]] ; then
+    show "Directory $new_ver_dir doesn't exist" $RED
+    exit 1
+  fi
+
   sources=$(grep '+++' "$patch_file" | tr "\t" " " | cut -f2 -d" " | cut -f2-99 -d "/")
 
   show ""

--- a/webkaos.spec
+++ b/webkaos.spec
@@ -44,10 +44,10 @@
 %define service_name         %{name}
 %define service_home         %{_cachedir}/%{service_name}
 
-%define boring_commit        e1068b76bd1d7f6ea06c90faa523ad8d562ec11b
+%define boring_commit        8c9ceadc58f425bd5edc71c349ef55e1a516302d
 %define psol_ver             1.12.34.2
-%define lua_module_ver       0.10.10
-%define mh_module_ver        0.32
+%define lua_module_ver       0.10.11
+%define mh_module_ver        0.33
 %define pcre_ver             8.41
 %define zlib_ver             1.2.11
 
@@ -58,8 +58,8 @@
 
 Summary:              Superb high performance web server
 Name:                 webkaos
-Version:              1.13.6
-Release:              2%{?dist}
+Version:              1.13.7
+Release:              0%{?dist}
 License:              2-clause BSD-like license
 Group:                System Environment/Daemons
 Vendor:               Nginx / Google / CloudFlare / ESSENTIALKAOS
@@ -100,8 +100,6 @@ Patch3:               boringssl.patch
 # https://github.com/cloudflare/sslconfig/blob/master/patches/nginx__1.13.0_http2_spdy.patch
 Patch4:               %{name}-http2-spdy.patch
 Patch5:               boringssl-tls13-support.patch
-
-
 # Patch for build with nginx >= 1.13.4
 Patch6:               ngx_pagespeed-build-fix.patch
 
@@ -458,7 +456,11 @@ exit 0
 %{__chown} root:root %{_logdir}/%{name}
 
 if [[ $1 -eq 1 ]] ; then
-  %{__sysctl} enable %{name}.service &>/dev/null || :
+  %if 0%{?rhel} >= 7
+    %{__sysctl} enable %{name}.service &>/dev/null || :
+  %else
+    %{__chkconfig} --add %{name} &>/dev/null || :
+  %endif
 
   # Generate unique nonce for common.conf
   sed -i "s/{RANDOM}/`mktemp -u XXXXXXXXXXXX`/" \
@@ -510,7 +512,7 @@ if [[ $1 -ge 1 ]] ; then
 %if 0%{?rhel} >= 7
   %{__sysctl} daemon-reload &>/dev/null || :
 %endif
-  %{__service} %{service_name} upgrade &>/dev/null || :
+%{__service} %{service_name} upgrade &>/dev/null || :
 fi
 
 
@@ -596,6 +598,13 @@ rm -rf %{buildroot}
 ###############################################################################
 
 %changelog
+* Tue Nov 28 2017 Anton Novojilov <andy@essentialkaos.com> - 1.13.7-0
+- Nginx updated to 1.13.5
+- BoringSSL updated to latest version
+- Lua module updated to 0.10.11
+- More Headers module updated to 0.33
+- Fixed bug with autostart on CentOS6
+
 * Tue Nov 07 2017 Anton Novojilov <andy@essentialkaos.com> - 1.13.6-2
 - Added '--with-compat' option for improved compatibility with dynamic modules
 - Improved extended preferences
@@ -604,7 +613,7 @@ rm -rf %{buildroot}
 - Fixed TLS 1.3 support
 
 * Sat Oct 14 2017 Anton Novojilov <andy@essentialkaos.com> - 1.13.6-0
-- Nginx updated to 1.13.5
+- Nginx updated to 1.13.6
 - BoringSSL updated to latest version
 
 * Wed Sep 20 2017 Anton Novojilov <andy@essentialkaos.com> - 1.13.5-0

--- a/webkaos.spec
+++ b/webkaos.spec
@@ -599,7 +599,7 @@ rm -rf %{buildroot}
 
 %changelog
 * Tue Nov 28 2017 Anton Novojilov <andy@essentialkaos.com> - 1.13.7-0
-- Nginx updated to 1.13.5
+- Nginx updated to 1.13.7
 - BoringSSL updated to latest version
 - Lua module updated to 0.10.11
 - More Headers module updated to 0.33


### PR DESCRIPTION
#### Improvements
- Nginx updated to 1.13.7
- BoringSSL updated to latest version
- Lua module updated to 0.10.11
- More Headers module updated to 0.33
- Improved `patch-proc.sh` script

#### Bugfixes
- Fixed bug with autostart on CentOS6