### PR TITLE
Version 1.13.10.1

### DIFF
--- a/SOURCES/webkaos.conf
+++ b/SOURCES/webkaos.conf
@@ -126,7 +126,7 @@ http {
   ssl_protocols              TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
   ssl_dhparam                /etc/webkaos/ssl/dhparam.pem;
 
-  resolver                   8.8.4.4 8.8.8.8 valid=300s;
+  resolver                   1.0.0.1 1.1.1.1 valid=300s;
   resolver_timeout           10s;
 
   ##############################################################################

--- a/webkaos.spec
+++ b/webkaos.spec
@@ -51,9 +51,9 @@
 %define service_name         %{name}
 %define service_home         %{_cachedir}/%{service_name}
 
-%define boring_commit        d61334d187a33336bc4cf4425d997e1ec8bcfa48
+%define boring_commit        7a62ab1938965de5cf9d2991ae6b57df781e63d1
 %define psol_ver             1.12.34.2
-%define lua_module_ver       0.10.11
+%define lua_module_ver       0.10.12rc2
 %define mh_module_ver        0.33
 %define pcre_ver             8.42
 %define zlib_ver             1.2.11
@@ -111,17 +111,19 @@ Patch6:               ngx_pagespeed-build-force.patch
 
 BuildRoot:            %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
-Requires:             initscripts >= 8.36 kaosv >= 2.12
+Requires:             initscripts >= 8.36 kaosv >= 2.15
 Requires:             gd libXpm libxslt libluajit
 
 BuildRequires:        make perl libluajit-devel cmake golang
 
+# http://mirror.centos.org/centos/6/sclo/x86_64/rh/devtoolset-3/
+# http://mirror.centos.org/centos/7/sclo/x86_64/rh/devtoolset-3/
+BuildRequires:        devtoolset-3-gcc-c++ devtoolset-3-binutils
+
 %if 0%{?rhel} >= 7
 Requires:             systemd
-BuildRequires:        gcc-c++
 %else
 Requires:             chkconfig
-BuildRequires:        devtoolset-2-gcc-c++ devtoolset-2-binutils
 %endif
 
 Requires(pre):        shadow-utils
@@ -202,10 +204,8 @@ mv lua-nginx-module-%{lua_module_ver}/README.markdown ./LUAMODULE-README.markdow
 
 mv headers-more-nginx-module-%{mh_module_ver}/README.markdown ./HEADERSMORE-README.markdown
 
-%if 0%{?rhel} < 7
-# Use gcc and gcc-c++ from devtoolset for build on CentOS6
-export PATH="/opt/rh/devtoolset-2/root/usr/bin:$PATH"
-%endif
+# Use gcc and gcc-c++ from DevToolSet 3
+export PATH="/opt/rh/devtoolset-3/root/usr/bin:$PATH"
 
 # BoringSSL Build ##############################################################
 
@@ -601,6 +601,9 @@ rm -rf %{buildroot}
 %changelog
 * Tue Apr 03 2018 Anton Novojilov <andy@essentialkaos.com> - 1.13.10-1
 - Google Public DNS replaced by Cloudflare Public DNS
+- Using devtoolset-3 for build on all systems
+- BoringSSL updated to latest version
+- Lua module updated to 0.10.12rc2
 
 * Tue Mar 20 2018 Anton Novojilov <andy@essentialkaos.com> - 1.13.10-0
 - Nginx updated to 1.13.10

--- a/webkaos.spec
+++ b/webkaos.spec
@@ -163,7 +163,7 @@ Links for nginx compatibility.
 ################################################################################
 
 %prep
-%setup -q -n nginx-%{version}
+%setup -qn nginx-%{version}
 
 mkdir boringssl
 

--- a/webkaos.spec
+++ b/webkaos.spec
@@ -66,7 +66,7 @@
 Summary:              Superb high performance web server
 Name:                 webkaos
 Version:              1.13.10
-Release:              0%{?dist}
+Release:              1%{?dist}
 License:              2-clause BSD-like license
 Group:                System Environment/Daemons
 URL:                  https://github.com/essentialkaos/webkaos
@@ -599,6 +599,9 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Tue Apr 03 2018 Anton Novojilov <andy@essentialkaos.com> - 1.13.10-1
+- Google Public DNS replaced by Cloudflare Public DNS
+
 * Tue Mar 20 2018 Anton Novojilov <andy@essentialkaos.com> - 1.13.10-0
 - Nginx updated to 1.13.10
 - PCRE updated to 8.42
@@ -644,7 +647,7 @@ rm -rf %{buildroot}
 - Added support of HTTP status code 418 (I'm a teapot)
 
 * Sat Aug 12 2017 Anton Novojilov <andy@essentialkaos.com> - 1.13.4-1
-- Added CloudFlare's patch for SPDY support
+- Added Cloudflare's patch for SPDY support
 
 * Thu Aug 10 2017 Anton Novojilov <andy@essentialkaos.com> - 1.13.4-0
 - Nginx updated to 1.13.4


### PR DESCRIPTION
#### Improvements
* Google Public DNS replaced by Cloudflare Public DNS
* Using `devtoolset-3` for build on all systems
* BoringSSL updated to the latest version
* Lua module updated to `0.10.12rc2`