### PR TITLE
Version 1.15.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Feature list
 
-* Improved default SSL/TLS preferencies (A+ on [SSL Labs](https://www.ssllabs.com/ssltest/analyze.html?d=essentialkaos.com), [High-Tech Bridge](https://www.htbridge.com/ssl/?id=WHUz0U3v) and [Mozilla Observatory](https://observatory.mozilla.org/analyze.html?host=essentialkaos.com))
+* Improved default SSL/TLS preferencies (A+ on [SSL Labs](https://www.ssllabs.com/ssltest/analyze.html?d=essentialkaos.com), [High-Tech Bridge](https://www.htbridge.com/ssl/?id=WHUz0U3v) and [Mozilla Observatory](https://observatory.mozilla.org/analyze/essentialkaos.com))
 * [Dynamic TLS Records](https://blog.cloudflare.com/optimizing-tls-over-tcp-to-reduce-latency/) support
 * Latest version of [BoringSSL](https://boringssl.googlesource.com/boringssl/) with some state-of-the-art crypto features
 * TLS 1.3 support (RFC 8446)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Feature list
 
-* Improved default SSL/TLS preferencies (A+ on [SSL Labs](https://www.ssllabs.com/ssltest/analyze.html?d=essentialkaos.com), [High-Tech Bridge](https://www.htbridge.com/ssl/?id=5sLe8Oej) and [Mozilla Observatory](https://observatory.mozilla.org/analyze.html?host=essentialkaos.com))
+* Improved default SSL/TLS preferencies (A+ on [SSL Labs](https://www.ssllabs.com/ssltest/analyze.html?d=essentialkaos.com), [High-Tech Bridge](https://www.htbridge.com/ssl/?id=WHUz0U3v) and [Mozilla Observatory](https://observatory.mozilla.org/analyze.html?host=essentialkaos.com))
 * [Dynamic TLS Records](https://blog.cloudflare.com/optimizing-tls-over-tcp-to-reduce-latency/) support
 * Latest version of [BoringSSL](https://boringssl.googlesource.com/boringssl/) with some state-of-the-art crypto features
 * TLS 1.3 support (RFC 8446)

--- a/SOURCES/boringssl-c6-build-fix.patch
+++ b/SOURCES/boringssl-c6-build-fix.patch
@@ -1,0 +1,22 @@
+diff -urN boringssl-orig/include/openssl/bn.h boringssl/include/openssl/bn.h
+--- boringssl-orig/include/openssl/bn.h	2019-02-28 00:09:32.000000000 +0300
++++ boringssl/include/openssl/bn.h	2019-02-28 01:48:53.000000000 +0300
+@@ -126,6 +126,7 @@
+ #include <openssl/base.h>
+ #include <openssl/thread.h>
+ 
++#define __STDC_FORMAT_MACROS
+ #include <inttypes.h>  // for PRIu64 and friends
+ #include <stdio.h>  // for FILE*
+ 
+diff -urN boringssl-orig/ssl/test/bssl_shim.cc boringssl/ssl/test/bssl_shim.cc
+--- boringssl-orig/ssl/test/bssl_shim.cc	2019-02-28 00:09:32.000000000 +0300
++++ boringssl/ssl/test/bssl_shim.cc	2019-02-28 01:49:35.000000000 +0300
+@@ -33,6 +33,7 @@
+ #endif
+ 
+ #include <assert.h>
++#define __STDC_FORMAT_MACROS
+ #include <inttypes.h>
+ #include <string.h>
+ #include <time.h>

--- a/SOURCES/webkaos-dynamic-tls-records.patch
+++ b/SOURCES/webkaos-dynamic-tls-records.patch
@@ -1,7 +1,7 @@
-diff -urN nginx-1.15.4-orig/src/event/ngx_event_openssl.c nginx-1.15.4-dyntls/src/event/ngx_event_openssl.c
---- nginx-1.15.4-orig/src/event/ngx_event_openssl.c	2018-09-25 18:11:39.000000000 +0300
-+++ nginx-1.15.4-dyntls/src/event/ngx_event_openssl.c	2018-09-27 14:01:16.000000000 +0300
-@@ -1267,6 +1267,7 @@
+diff -urN nginx-1.15.8-orig/src/event/ngx_event_openssl.c nginx-1.15.8-dynamic/src/event/ngx_event_openssl.c
+--- nginx-1.15.8-orig/src/event/ngx_event_openssl.c	2018-12-25 17:53:03.000000000 +0300
++++ nginx-1.15.8-dynamic/src/event/ngx_event_openssl.c	2019-02-28 01:02:51.000000000 +0300
+@@ -1272,6 +1272,7 @@
  
      sc->buffer = ((flags & NGX_SSL_BUFFER) != 0);
      sc->buffer_size = ssl->buffer_size;
@@ -9,7 +9,7 @@ diff -urN nginx-1.15.4-orig/src/event/ngx_event_openssl.c nginx-1.15.4-dyntls/sr
  
      sc->session_ctx = ssl->ctx;
  
-@@ -2115,6 +2116,41 @@
+@@ -2124,6 +2125,41 @@
  
      for ( ;; ) {
  
@@ -51,7 +51,7 @@ diff -urN nginx-1.15.4-orig/src/event/ngx_event_openssl.c nginx-1.15.4-dyntls/sr
          while (in && buf->last < buf->end && send < limit) {
              if (in->buf->last_buf || in->buf->flush) {
                  flush = 1;
-@@ -2222,6 +2258,9 @@
+@@ -2231,6 +2267,9 @@
  
      if (n > 0) {
  
@@ -61,9 +61,9 @@ diff -urN nginx-1.15.4-orig/src/event/ngx_event_openssl.c nginx-1.15.4-dyntls/sr
          if (c->ssl->saved_read_handler) {
  
              c->read->handler = c->ssl->saved_read_handler;
-diff -urN nginx-1.15.4-orig/src/event/ngx_event_openssl.h nginx-1.15.4-dyntls/src/event/ngx_event_openssl.h
---- nginx-1.15.4-orig/src/event/ngx_event_openssl.h	2018-09-25 18:11:39.000000000 +0300
-+++ nginx-1.15.4-dyntls/src/event/ngx_event_openssl.h	2018-09-27 14:05:40.000000000 +0300
+diff -urN nginx-1.15.8-orig/src/event/ngx_event_openssl.h nginx-1.15.8-dynamic/src/event/ngx_event_openssl.h
+--- nginx-1.15.8-orig/src/event/ngx_event_openssl.h	2018-12-25 17:53:03.000000000 +0300
++++ nginx-1.15.8-dynamic/src/event/ngx_event_openssl.h	2019-02-28 01:18:55.000000000 +0300
 @@ -58,6 +58,12 @@
  #define ngx_ssl_session_t       SSL_SESSION
  #define ngx_ssl_conn_t          SSL
@@ -85,10 +85,10 @@ diff -urN nginx-1.15.4-orig/src/event/ngx_event_openssl.h nginx-1.15.4-dyntls/sr
  };
  
  
-@@ -98,6 +105,10 @@
-     unsigned                    try_early_data:1;
+@@ -99,6 +106,10 @@
      unsigned                    in_early:1;
      unsigned                    early_preread:1;
+     unsigned                    write_blocked:1;
 +
 +    ngx_ssl_dyn_rec_t           dyn_rec;
 +    ngx_msec_t                  dyn_rec_last_write;
@@ -96,7 +96,7 @@ diff -urN nginx-1.15.4-orig/src/event/ngx_event_openssl.h nginx-1.15.4-dyntls/sr
  };
  
  
-@@ -107,7 +118,7 @@
+@@ -108,7 +119,7 @@
  #define NGX_SSL_DFLT_BUILTIN_SCACHE  -5
  
  
@@ -105,9 +105,9 @@ diff -urN nginx-1.15.4-orig/src/event/ngx_event_openssl.h nginx-1.15.4-dyntls/sr
  
  typedef struct ngx_ssl_sess_id_s  ngx_ssl_sess_id_t;
  
-diff -urN nginx-1.15.4-orig/src/http/modules/ngx_http_ssl_module.c nginx-1.15.4-dyntls/src/http/modules/ngx_http_ssl_module.c
---- nginx-1.15.4-orig/src/http/modules/ngx_http_ssl_module.c	2018-09-25 18:11:39.000000000 +0300
-+++ nginx-1.15.4-dyntls/src/http/modules/ngx_http_ssl_module.c	2018-09-27 14:08:12.000000000 +0300
+diff -urN nginx-1.15.8-orig/src/http/modules/ngx_http_ssl_module.c nginx-1.15.8-dynamic/src/http/modules/ngx_http_ssl_module.c
+--- nginx-1.15.8-orig/src/http/modules/ngx_http_ssl_module.c	2018-12-25 17:53:03.000000000 +0300
++++ nginx-1.15.8-dynamic/src/http/modules/ngx_http_ssl_module.c	2019-02-28 01:12:04.000000000 +0300
 @@ -246,6 +246,41 @@
        offsetof(ngx_http_ssl_srv_conf_t, early_data),
        NULL },
@@ -207,14 +207,14 @@ diff -urN nginx-1.15.4-orig/src/http/modules/ngx_http_ssl_module.c nginx-1.15.4-
 +
 +    } else {
 +        conf->ssl.dyn_rec.timeout = 0;
-+    }   
++    }
 +
      return NGX_CONF_OK;
  }
  
-diff -urN nginx-1.15.4-orig/src/http/modules/ngx_http_ssl_module.h nginx-1.15.4-dyntls/src/http/modules/ngx_http_ssl_module.h
---- nginx-1.15.4-orig/src/http/modules/ngx_http_ssl_module.h	2018-09-25 18:11:39.000000000 +0300
-+++ nginx-1.15.4-dyntls/src/http/modules/ngx_http_ssl_module.h	2018-09-27 14:09:20.000000000 +0300
+diff -urN nginx-1.15.8-orig/src/http/modules/ngx_http_ssl_module.h nginx-1.15.8-dynamic/src/http/modules/ngx_http_ssl_module.h
+--- nginx-1.15.8-orig/src/http/modules/ngx_http_ssl_module.h	2018-12-25 17:53:03.000000000 +0300
++++ nginx-1.15.8-dynamic/src/http/modules/ngx_http_ssl_module.h	2019-02-28 01:12:51.000000000 +0300
 @@ -58,6 +58,12 @@
  
      u_char                         *file;

--- a/SOURCES/webkaos.init
+++ b/SOURCES/webkaos.init
@@ -155,9 +155,11 @@ gendhp() {
 }
 
 restart() {
-  if check ; then
-    kv.restart
+  if ! check ; then
+    return $ACTION_ERROR
   fi
+
+  kv.restart
 
   return $?
 }

--- a/SOURCES/webkaos.patch
+++ b/SOURCES/webkaos.patch
@@ -1,6 +1,6 @@
-diff -urN nginx-1.15.7-orig/auto/lib/openssl/make nginx-1.15.7/auto/lib/openssl/make
---- nginx-1.15.7-orig/auto/lib/openssl/make	2018-11-27 17:40:21.000000000 +0300
-+++ nginx-1.15.7/auto/lib/openssl/make	2018-11-29 02:07:31.129460466 +0300
+diff -urN nginx-1.15.9-orig/auto/lib/openssl/make nginx-1.15.9/auto/lib/openssl/make
+--- nginx-1.15.9-orig/auto/lib/openssl/make	2019-02-26 18:29:22.000000000 +0300
++++ nginx-1.15.9/auto/lib/openssl/make	2019-02-28 02:43:00.775768195 +0300
 @@ -45,18 +45,18 @@
              /*) ngx_prefix="$OPENSSL/.openssl" ;;
              *)  ngx_prefix="$PWD/$OPENSSL/.openssl" ;;
@@ -24,9 +24,9 @@ diff -urN nginx-1.15.7-orig/auto/lib/openssl/make nginx-1.15.7/auto/lib/openssl/
      ;;
  
  esac
-diff -urN nginx-1.15.7-orig/src/core/nginx.c nginx-1.15.7/src/core/nginx.c
---- nginx-1.15.7-orig/src/core/nginx.c	2018-11-27 17:40:21.000000000 +0300
-+++ nginx-1.15.7/src/core/nginx.c	2018-11-29 02:07:31.136460399 +0300
+diff -urN nginx-1.15.9-orig/src/core/nginx.c nginx-1.15.9/src/core/nginx.c
+--- nginx-1.15.9-orig/src/core/nginx.c	2019-02-26 18:29:22.000000000 +0300
++++ nginx-1.15.9/src/core/nginx.c	2019-02-28 02:43:00.781768140 +0300
 @@ -389,13 +389,13 @@
  static void
  ngx_show_version_info(void)
@@ -45,13 +45,13 @@ diff -urN nginx-1.15.7-orig/src/core/nginx.c nginx-1.15.7/src/core/nginx.c
              "Options:" NGX_LINEFEED
              "  -?,-h         : this help" NGX_LINEFEED
              "  -v            : show version and exit" NGX_LINEFEED
-diff -urN nginx-1.15.7-orig/src/core/nginx.h nginx-1.15.7/src/core/nginx.h
---- nginx-1.15.7-orig/src/core/nginx.h	2018-11-27 17:40:21.000000000 +0300
-+++ nginx-1.15.7/src/core/nginx.h	2018-11-29 02:08:05.000000000 +0300
+diff -urN nginx-1.15.9-orig/src/core/nginx.h nginx-1.15.9/src/core/nginx.h
+--- nginx-1.15.9-orig/src/core/nginx.h	2019-02-26 18:29:22.000000000 +0300
++++ nginx-1.15.9/src/core/nginx.h	2019-02-28 02:44:00.000000000 +0300
 @@ -11,7 +11,7 @@
  
- #define nginx_version      1015007
- #define NGINX_VERSION      "1.15.7"
+ #define nginx_version      1015009
+ #define NGINX_VERSION      "1.15.9"
 -#define NGINX_VER          "nginx/" NGINX_VERSION
 +#define NGINX_VER          "webkaos/" NGINX_VERSION
  
@@ -66,9 +66,9 @@ diff -urN nginx-1.15.7-orig/src/core/nginx.h nginx-1.15.7/src/core/nginx.h
  #define NGX_OLDPID_EXT     ".oldbin"
  
  
-diff -urN nginx-1.15.7-orig/src/core/ngx_log.c nginx-1.15.7/src/core/ngx_log.c
---- nginx-1.15.7-orig/src/core/ngx_log.c	2018-11-27 17:40:21.000000000 +0300
-+++ nginx-1.15.7/src/core/ngx_log.c	2018-11-29 02:07:31.147460293 +0300
+diff -urN nginx-1.15.9-orig/src/core/ngx_log.c nginx-1.15.9/src/core/ngx_log.c
+--- nginx-1.15.9-orig/src/core/ngx_log.c	2019-02-26 18:29:22.000000000 +0300
++++ nginx-1.15.9/src/core/ngx_log.c	2019-02-28 02:43:00.790768056 +0300
 @@ -202,9 +202,9 @@
          return;
      }
@@ -99,10 +99,10 @@ diff -urN nginx-1.15.7-orig/src/core/ngx_log.c nginx-1.15.7/src/core/ngx_log.c
          return NGX_CONF_ERROR;
  #endif
  
-diff -urN nginx-1.15.7-orig/src/http/modules/ngx_http_autoindex_module.c nginx-1.15.7/src/http/modules/ngx_http_autoindex_module.c
---- nginx-1.15.7-orig/src/http/modules/ngx_http_autoindex_module.c	2018-11-27 17:40:21.000000000 +0300
-+++ nginx-1.15.7/src/http/modules/ngx_http_autoindex_module.c	2018-11-29 02:07:31.154460225 +0300
-@@ -451,9 +451,11 @@
+diff -urN nginx-1.15.9-orig/src/http/modules/ngx_http_autoindex_module.c nginx-1.15.9/src/http/modules/ngx_http_autoindex_module.c
+--- nginx-1.15.9-orig/src/http/modules/ngx_http_autoindex_module.c	2019-02-26 18:29:22.000000000 +0300
++++ nginx-1.15.9/src/http/modules/ngx_http_autoindex_module.c	2019-02-28 02:43:00.796768001 +0300
+@@ -449,9 +449,11 @@
      ;
  
      static u_char  header[] =
@@ -116,7 +116,7 @@ diff -urN nginx-1.15.7-orig/src/http/modules/ngx_http_autoindex_module.c nginx-1
      ;
  
      static u_char  tail[] =
-@@ -480,7 +482,7 @@
+@@ -478,7 +480,7 @@
            + r->uri.len + escape_html
            + sizeof(header) - 1
            + r->uri.len + escape_html
@@ -125,25 +125,25 @@ diff -urN nginx-1.15.7-orig/src/http/modules/ngx_http_autoindex_module.c nginx-1
            + sizeof("<hr><pre><a href=\"../\">../</a>" CRLF) - 1
            + sizeof("</pre><hr>") - 1
            + sizeof(tail) - 1;
-@@ -501,7 +503,7 @@
+@@ -499,7 +501,7 @@
              entry[i].utf_len = entry[i].name.len;
          }
  
--        len += sizeof("<a href=\"") - 1
-+        len += sizeof("<a id=\"dir\" href=\"") - 1
-             + entry[i].name.len + entry[i].escape
-             + 1                                          /* 1 is for "/" */
-             + sizeof("\">") - 1
-@@ -509,7 +511,7 @@
-             + entry[i].escape_html
-             + NGX_HTTP_AUTOINDEX_NAME_LEN + sizeof("&gt;") - 2
-             + sizeof("</a>") - 1
--            + sizeof(" 28-Sep-1970 12:00 ") - 1
-+            + sizeof(" 28/Sep/1970 12:00 ") - 1
-             + 20                                         /* the file size */
-             + 2;
-     }
-@@ -532,16 +534,20 @@
+-        entry_len = sizeof("<a href=\"") - 1
++        entry_len = sizeof("<a id=\"dir\" href=\"") - 1
+                   + entry[i].name.len + entry[i].escape
+                   + 1                                    /* 1 is for "/" */
+                   + sizeof("\">") - 1
+@@ -507,7 +509,7 @@
+                   + entry[i].escape_html
+                   + NGX_HTTP_AUTOINDEX_NAME_LEN + sizeof("&gt;") - 2
+                   + sizeof("</a>") - 1
+-                  + sizeof(" 28-Sep-1970 12:00 ") - 1
++                  + sizeof(" 28/Sep/1970 12:00 ") - 1
+                   + 20                                   /* the file size */
+                   + 2;
+ 
+@@ -536,16 +538,20 @@
          b->last = ngx_cpymem(b->last, r->uri.data, r->uri.len);
      }
  
@@ -168,7 +168,7 @@ diff -urN nginx-1.15.7-orig/src/http/modules/ngx_http_autoindex_module.c nginx-1
  
          if (entry[i].escape) {
              ngx_escape_uri(b->last, entry[i].name.data, entry[i].name.len,
-@@ -623,7 +629,7 @@
+@@ -627,7 +633,7 @@
  
          ngx_gmtime(entry[i].mtime + tp->gmtoff * 60 * alcf->localtime, &tm);
  
@@ -177,9 +177,9 @@ diff -urN nginx-1.15.7-orig/src/http/modules/ngx_http_autoindex_module.c nginx-1
                                tm.ngx_tm_mday,
                                months[tm.ngx_tm_mon - 1],
                                tm.ngx_tm_year,
-diff -urN nginx-1.15.7-orig/src/http/ngx_http_header_filter_module.c nginx-1.15.7/src/http/ngx_http_header_filter_module.c
---- nginx-1.15.7-orig/src/http/ngx_http_header_filter_module.c	2018-11-27 17:40:21.000000000 +0300
-+++ nginx-1.15.7/src/http/ngx_http_header_filter_module.c	2018-11-29 02:07:31.160460167 +0300
+diff -urN nginx-1.15.9-orig/src/http/ngx_http_header_filter_module.c nginx-1.15.9/src/http/ngx_http_header_filter_module.c
+--- nginx-1.15.9-orig/src/http/ngx_http_header_filter_module.c	2019-02-26 18:29:22.000000000 +0300
++++ nginx-1.15.9/src/http/ngx_http_header_filter_module.c	2019-02-28 02:43:00.802767945 +0300
 @@ -46,7 +46,7 @@
  };
  
@@ -230,9 +230,9 @@ diff -urN nginx-1.15.7-orig/src/http/ngx_http_header_filter_module.c nginx-1.15.
  #define NGX_HTTP_OFF_5XX   (NGX_HTTP_LAST_4XX - 400 + NGX_HTTP_OFF_4XX)
  
      ngx_string("500 Internal Server Error"),
-diff -urN nginx-1.15.7-orig/src/http/ngx_http_special_response.c nginx-1.15.7/src/http/ngx_http_special_response.c
---- nginx-1.15.7-orig/src/http/ngx_http_special_response.c	2018-11-27 17:40:21.000000000 +0300
-+++ nginx-1.15.7/src/http/ngx_http_special_response.c	2018-11-29 02:07:31.166460110 +0300
+diff -urN nginx-1.15.9-orig/src/http/ngx_http_special_response.c nginx-1.15.9/src/http/ngx_http_special_response.c
+--- nginx-1.15.9-orig/src/http/ngx_http_special_response.c	2019-02-26 18:29:22.000000000 +0300
++++ nginx-1.15.9/src/http/ngx_http_special_response.c	2019-02-28 02:43:00.807767899 +0300
 @@ -19,21 +19,21 @@
  
  
@@ -705,9 +705,9 @@ diff -urN nginx-1.15.7-orig/src/http/ngx_http_special_response.c nginx-1.15.7/sr
  #define NGX_HTTP_OFF_5XX   (NGX_HTTP_LAST_4XX - 400 + NGX_HTTP_OFF_4XX)
  
      ngx_string(ngx_http_error_494_page), /* 494, request header too large */
-diff -urN nginx-1.15.7-orig/src/http/v2/ngx_http_v2_filter_module.c nginx-1.15.7/src/http/v2/ngx_http_v2_filter_module.c
---- nginx-1.15.7-orig/src/http/v2/ngx_http_v2_filter_module.c	2018-11-27 17:40:21.000000000 +0300
-+++ nginx-1.15.7/src/http/v2/ngx_http_v2_filter_module.c	2018-11-29 02:07:31.172460052 +0300
+diff -urN nginx-1.15.9-orig/src/http/v2/ngx_http_v2_filter_module.c nginx-1.15.9/src/http/v2/ngx_http_v2_filter_module.c
+--- nginx-1.15.9-orig/src/http/v2/ngx_http_v2_filter_module.c	2019-02-26 18:29:22.000000000 +0300
++++ nginx-1.15.9/src/http/v2/ngx_http_v2_filter_module.c	2019-02-28 02:43:00.813767843 +0300
 @@ -148,7 +148,7 @@
      ngx_http_core_srv_conf_t  *cscf;
      u_char                     addr[NGX_SOCKADDR_STRLEN];
@@ -726,9 +726,9 @@ diff -urN nginx-1.15.7-orig/src/http/v2/ngx_http_v2_filter_module.c nginx-1.15.7
          }
  
          *pos++ = ngx_http_v2_inc_indexed(NGX_HTTP_V2_SERVER_INDEX);
-diff -urN nginx-1.15.7-orig/src/os/unix/ngx_setproctitle.c nginx-1.15.7/src/os/unix/ngx_setproctitle.c
---- nginx-1.15.7-orig/src/os/unix/ngx_setproctitle.c	2018-11-27 17:40:21.000000000 +0300
-+++ nginx-1.15.7/src/os/unix/ngx_setproctitle.c	2018-11-29 02:07:31.178459994 +0300
+diff -urN nginx-1.15.9-orig/src/os/unix/ngx_setproctitle.c nginx-1.15.9/src/os/unix/ngx_setproctitle.c
+--- nginx-1.15.9-orig/src/os/unix/ngx_setproctitle.c	2019-02-26 18:29:22.000000000 +0300
++++ nginx-1.15.9/src/os/unix/ngx_setproctitle.c	2019-02-28 02:43:00.819767788 +0300
 @@ -89,7 +89,7 @@
  
      ngx_os_argv[1] = NULL;

--- a/webkaos.spec
+++ b/webkaos.spec
@@ -44,17 +44,17 @@
 %define service_name         %{name}
 %define service_home         %{_cachedir}/%{service_name}
 
-%define boring_commit        5ecfb10d54600dc6ee6f3070b842f5289b6e6c1e
-%define lua_module_ver       0.10.13
+%define boring_commit        a6124742d008e7cd4613833350a16d68537687c9
+%define lua_module_ver       0.10.14
 %define mh_module_ver        0.33
-%define pcre_ver             8.42
+%define pcre_ver             8.43
 %define zlib_ver             1.2.11
 
 ################################################################################
 
 Summary:              Superb high performance web server
 Name:                 webkaos
-Version:              1.15.7
+Version:              1.15.9
 Release:              0%{?dist}
 License:              2-clause BSD-like license
 Group:                System Environment/Daemons
@@ -90,6 +90,7 @@ Patch3:               boringssl.patch
 # https://github.com/cloudflare/sslconfig/blob/master/patches/nginx__1.13.0_http2_spdy.patch
 Patch4:               %{name}-http2-spdy.patch
 Patch5:               boringssl-tls13-support.patch
+Patch6:               boringssl-c6-build-fix.patch
 
 BuildRoot:            %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
@@ -163,6 +164,9 @@ tar xzvf %{SOURCE54}
 
 pushd boringssl
 %patch5 -p1
+%if 0%{?rhel} == 6
+%patch6 -p1
+%endif
 popd
 
 %build
@@ -558,6 +562,17 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Thu Feb 28 2019 Anton Novojilov <andy@essentialkaos.com> - 1.15.9-0
+- Nginx updated to 1.15.9
+
+* Thu Feb 28 2019 Anton Novojilov <andy@essentialkaos.com> - 1.15.8-0
+- Nginx updated to 1.15.8
+- PCRE updated to 8.43
+- Lua module updated to 0.10.14
+- BoringSSL updated to the latest version
+- Updated dynamic TLS records patch for compatibility with the latest version
+- Added patch for building BoringSSL on CentOS 6
+
 * Thu Nov 29 2018 Anton Novojilov <andy@essentialkaos.com> - 1.15.7-0
 - Nginx updated to 1.15.7
 - BoringSSL updated


### PR DESCRIPTION
#### Improvements
- Nginx updated to `1.15.9`
- PCRE updated to `8.43`
- Lua module updated to `0.10.14`
- BoringSSL updated to the latest version
- Updated dynamic TLS records patch for compatibility with the latest version
- Added patch for building BoringSSL on CentOS 6
- LuaJIT replaced by OpenResty's fork

#### Bugfixes
- Fixed exit code for failed validation while restart in init script