### PR TITLE
Version 1.15.10

### DIFF
--- a/SOURCES/boringssl-tls13-support.patch
+++ b/SOURCES/boringssl-tls13-support.patch
@@ -1,7 +1,7 @@
 diff -urN boringssl-orig/ssl/s3_lib.cc boringssl/ssl/s3_lib.cc
---- boringssl-orig/ssl/s3_lib.cc	2017-11-27 23:19:17.297484878 +0100
-+++ boringssl/ssl/s3_lib.cc	2017-11-27 23:20:24.000000000 +0100
-@@ -199,7 +199,7 @@
+--- boringssl-orig/ssl/s3_lib.cc	2019-04-09 00:27:58.157453794 +0300
++++ boringssl/ssl/s3_lib.cc	2019-04-09 00:29:57.000000000 +0300
+@@ -202,7 +202,7 @@
    // TODO(davidben): Move this field into |s3|, have it store the normalized
    // protocol version, and implement this pre-negotiation quirk in |SSL_version|
    // at the API boundary rather than in internal state.
@@ -11,14 +11,14 @@ diff -urN boringssl-orig/ssl/s3_lib.cc boringssl/ssl/s3_lib.cc
  }
  
 diff -urN boringssl-orig/ssl/ssl_versions.cc boringssl/ssl/ssl_versions.cc
---- boringssl-orig/ssl/ssl_versions.cc	2017-11-27 23:19:17.294484878 +0100
-+++ boringssl/ssl/ssl_versions.cc	2017-11-27 23:21:15.000000000 +0100
-@@ -209,7 +209,7 @@
+--- boringssl-orig/ssl/ssl_versions.cc	2019-04-09 00:27:58.158453785 +0300
++++ boringssl/ssl/ssl_versions.cc	2019-04-09 00:41:47.000000000 +0300
+@@ -158,7 +158,7 @@
                              uint16_t version) {
    // Zero is interpreted as the default maximum version.
    if (version == 0) {
--    *out = TLS1_2_VERSION;
-+    *out = TLS1_3_VERSION;
+-    *out = method->is_dtls ? DTLS1_2_VERSION : TLS1_2_VERSION;
++    *out = method->is_dtls ? DTLS1_2_VERSION : TLS1_3_VERSION;
      return true;
    }
  

--- a/SOURCES/webkaos.patch
+++ b/SOURCES/webkaos.patch
@@ -1,6 +1,6 @@
-diff -urN nginx-1.15.9-orig/auto/lib/openssl/make nginx-1.15.9/auto/lib/openssl/make
---- nginx-1.15.9-orig/auto/lib/openssl/make	2019-02-26 18:29:22.000000000 +0300
-+++ nginx-1.15.9/auto/lib/openssl/make	2019-02-28 02:43:00.775768195 +0300
+diff -urN nginx-1.15.10-orig/auto/lib/openssl/make nginx-1.15.10/auto/lib/openssl/make
+--- nginx-1.15.10-orig/auto/lib/openssl/make	2019-03-26 17:06:55.000000000 +0300
++++ nginx-1.15.10/auto/lib/openssl/make	2019-04-09 00:03:13.912783334 +0300
 @@ -45,18 +45,18 @@
              /*) ngx_prefix="$OPENSSL/.openssl" ;;
              *)  ngx_prefix="$PWD/$OPENSSL/.openssl" ;;
@@ -24,9 +24,9 @@ diff -urN nginx-1.15.9-orig/auto/lib/openssl/make nginx-1.15.9/auto/lib/openssl/
      ;;
  
  esac
-diff -urN nginx-1.15.9-orig/src/core/nginx.c nginx-1.15.9/src/core/nginx.c
---- nginx-1.15.9-orig/src/core/nginx.c	2019-02-26 18:29:22.000000000 +0300
-+++ nginx-1.15.9/src/core/nginx.c	2019-02-28 02:43:00.781768140 +0300
+diff -urN nginx-1.15.10-orig/src/core/nginx.c nginx-1.15.10/src/core/nginx.c
+--- nginx-1.15.10-orig/src/core/nginx.c	2019-03-26 17:06:55.000000000 +0300
++++ nginx-1.15.10/src/core/nginx.c	2019-04-09 00:03:13.918783280 +0300
 @@ -389,13 +389,13 @@
  static void
  ngx_show_version_info(void)
@@ -45,13 +45,13 @@ diff -urN nginx-1.15.9-orig/src/core/nginx.c nginx-1.15.9/src/core/nginx.c
              "Options:" NGX_LINEFEED
              "  -?,-h         : this help" NGX_LINEFEED
              "  -v            : show version and exit" NGX_LINEFEED
-diff -urN nginx-1.15.9-orig/src/core/nginx.h nginx-1.15.9/src/core/nginx.h
---- nginx-1.15.9-orig/src/core/nginx.h	2019-02-26 18:29:22.000000000 +0300
-+++ nginx-1.15.9/src/core/nginx.h	2019-02-28 02:44:00.000000000 +0300
+diff -urN nginx-1.15.10-orig/src/core/nginx.h nginx-1.15.10/src/core/nginx.h
+--- nginx-1.15.10-orig/src/core/nginx.h	2019-03-26 17:06:55.000000000 +0300
++++ nginx-1.15.10/src/core/nginx.h	2019-04-09 00:07:45.000000000 +0300
 @@ -11,7 +11,7 @@
  
- #define nginx_version      1015009
- #define NGINX_VERSION      "1.15.9"
+ #define nginx_version      1015010
+ #define NGINX_VERSION      "1.15.10"
 -#define NGINX_VER          "nginx/" NGINX_VERSION
 +#define NGINX_VER          "webkaos/" NGINX_VERSION
  
@@ -66,9 +66,9 @@ diff -urN nginx-1.15.9-orig/src/core/nginx.h nginx-1.15.9/src/core/nginx.h
  #define NGX_OLDPID_EXT     ".oldbin"
  
  
-diff -urN nginx-1.15.9-orig/src/core/ngx_log.c nginx-1.15.9/src/core/ngx_log.c
---- nginx-1.15.9-orig/src/core/ngx_log.c	2019-02-26 18:29:22.000000000 +0300
-+++ nginx-1.15.9/src/core/ngx_log.c	2019-02-28 02:43:00.790768056 +0300
+diff -urN nginx-1.15.10-orig/src/core/ngx_log.c nginx-1.15.10/src/core/ngx_log.c
+--- nginx-1.15.10-orig/src/core/ngx_log.c	2019-03-26 17:06:55.000000000 +0300
++++ nginx-1.15.10/src/core/ngx_log.c	2019-04-09 00:03:13.928783190 +0300
 @@ -202,9 +202,9 @@
          return;
      }
@@ -99,9 +99,9 @@ diff -urN nginx-1.15.9-orig/src/core/ngx_log.c nginx-1.15.9/src/core/ngx_log.c
          return NGX_CONF_ERROR;
  #endif
  
-diff -urN nginx-1.15.9-orig/src/http/modules/ngx_http_autoindex_module.c nginx-1.15.9/src/http/modules/ngx_http_autoindex_module.c
---- nginx-1.15.9-orig/src/http/modules/ngx_http_autoindex_module.c	2019-02-26 18:29:22.000000000 +0300
-+++ nginx-1.15.9/src/http/modules/ngx_http_autoindex_module.c	2019-02-28 02:43:00.796768001 +0300
+diff -urN nginx-1.15.10-orig/src/http/modules/ngx_http_autoindex_module.c nginx-1.15.10/src/http/modules/ngx_http_autoindex_module.c
+--- nginx-1.15.10-orig/src/http/modules/ngx_http_autoindex_module.c	2019-03-26 17:06:55.000000000 +0300
++++ nginx-1.15.10/src/http/modules/ngx_http_autoindex_module.c	2019-04-09 00:03:13.934783136 +0300
 @@ -449,9 +449,11 @@
      ;
  
@@ -177,9 +177,9 @@ diff -urN nginx-1.15.9-orig/src/http/modules/ngx_http_autoindex_module.c nginx-1
                                tm.ngx_tm_mday,
                                months[tm.ngx_tm_mon - 1],
                                tm.ngx_tm_year,
-diff -urN nginx-1.15.9-orig/src/http/ngx_http_header_filter_module.c nginx-1.15.9/src/http/ngx_http_header_filter_module.c
---- nginx-1.15.9-orig/src/http/ngx_http_header_filter_module.c	2019-02-26 18:29:22.000000000 +0300
-+++ nginx-1.15.9/src/http/ngx_http_header_filter_module.c	2019-02-28 02:43:00.802767945 +0300
+diff -urN nginx-1.15.10-orig/src/http/ngx_http_header_filter_module.c nginx-1.15.10/src/http/ngx_http_header_filter_module.c
+--- nginx-1.15.10-orig/src/http/ngx_http_header_filter_module.c	2019-03-26 17:06:55.000000000 +0300
++++ nginx-1.15.10/src/http/ngx_http_header_filter_module.c	2019-04-09 00:03:13.939783091 +0300
 @@ -46,7 +46,7 @@
  };
  
@@ -230,9 +230,9 @@ diff -urN nginx-1.15.9-orig/src/http/ngx_http_header_filter_module.c nginx-1.15.
  #define NGX_HTTP_OFF_5XX   (NGX_HTTP_LAST_4XX - 400 + NGX_HTTP_OFF_4XX)
  
      ngx_string("500 Internal Server Error"),
-diff -urN nginx-1.15.9-orig/src/http/ngx_http_special_response.c nginx-1.15.9/src/http/ngx_http_special_response.c
---- nginx-1.15.9-orig/src/http/ngx_http_special_response.c	2019-02-26 18:29:22.000000000 +0300
-+++ nginx-1.15.9/src/http/ngx_http_special_response.c	2019-02-28 02:43:00.807767899 +0300
+diff -urN nginx-1.15.10-orig/src/http/ngx_http_special_response.c nginx-1.15.10/src/http/ngx_http_special_response.c
+--- nginx-1.15.10-orig/src/http/ngx_http_special_response.c	2019-03-26 17:06:55.000000000 +0300
++++ nginx-1.15.10/src/http/ngx_http_special_response.c	2019-04-09 00:03:13.945783037 +0300
 @@ -19,21 +19,21 @@
  
  
@@ -705,9 +705,9 @@ diff -urN nginx-1.15.9-orig/src/http/ngx_http_special_response.c nginx-1.15.9/sr
  #define NGX_HTTP_OFF_5XX   (NGX_HTTP_LAST_4XX - 400 + NGX_HTTP_OFF_4XX)
  
      ngx_string(ngx_http_error_494_page), /* 494, request header too large */
-diff -urN nginx-1.15.9-orig/src/http/v2/ngx_http_v2_filter_module.c nginx-1.15.9/src/http/v2/ngx_http_v2_filter_module.c
---- nginx-1.15.9-orig/src/http/v2/ngx_http_v2_filter_module.c	2019-02-26 18:29:22.000000000 +0300
-+++ nginx-1.15.9/src/http/v2/ngx_http_v2_filter_module.c	2019-02-28 02:43:00.813767843 +0300
+diff -urN nginx-1.15.10-orig/src/http/v2/ngx_http_v2_filter_module.c nginx-1.15.10/src/http/v2/ngx_http_v2_filter_module.c
+--- nginx-1.15.10-orig/src/http/v2/ngx_http_v2_filter_module.c	2019-03-26 17:06:55.000000000 +0300
++++ nginx-1.15.10/src/http/v2/ngx_http_v2_filter_module.c	2019-04-09 00:03:13.951782983 +0300
 @@ -148,7 +148,7 @@
      ngx_http_core_srv_conf_t  *cscf;
      u_char                     addr[NGX_SOCKADDR_STRLEN];
@@ -726,9 +726,9 @@ diff -urN nginx-1.15.9-orig/src/http/v2/ngx_http_v2_filter_module.c nginx-1.15.9
          }
  
          *pos++ = ngx_http_v2_inc_indexed(NGX_HTTP_V2_SERVER_INDEX);
-diff -urN nginx-1.15.9-orig/src/os/unix/ngx_setproctitle.c nginx-1.15.9/src/os/unix/ngx_setproctitle.c
---- nginx-1.15.9-orig/src/os/unix/ngx_setproctitle.c	2019-02-26 18:29:22.000000000 +0300
-+++ nginx-1.15.9/src/os/unix/ngx_setproctitle.c	2019-02-28 02:43:00.819767788 +0300
+diff -urN nginx-1.15.10-orig/src/os/unix/ngx_setproctitle.c nginx-1.15.10/src/os/unix/ngx_setproctitle.c
+--- nginx-1.15.10-orig/src/os/unix/ngx_setproctitle.c	2019-03-26 17:06:55.000000000 +0300
++++ nginx-1.15.10/src/os/unix/ngx_setproctitle.c	2019-04-09 00:03:13.956782939 +0300
 @@ -89,7 +89,7 @@
  
      ngx_os_argv[1] = NULL;

--- a/webkaos.spec
+++ b/webkaos.spec
@@ -44,18 +44,18 @@
 %define service_name         %{name}
 %define service_home         %{_cachedir}/%{service_name}
 
-%define boring_commit        a6124742d008e7cd4613833350a16d68537687c9
+%define boring_commit        a26d01719b4c56241424c8cfed2ca326ea229790
 %define lua_module_ver       0.10.14
 %define mh_module_ver        0.33
 %define pcre_ver             8.43
 %define zlib_ver             1.2.11
-%define luajit_ver           2.1-20190221
+%define luajit_ver           2.1-20190329
 
 ################################################################################
 
 Summary:              Superb high performance web server
 Name:                 webkaos
-Version:              1.15.9
+Version:              1.15.10
 Release:              0%{?dist}
 License:              2-clause BSD-like license
 Group:                System Environment/Daemons
@@ -578,6 +578,12 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Tue Apr 09 2019 Anton Novojilov <andy@essentialkaos.com> - 1.5.10-0
+- Nginx updated to 1.15.10
+- BoringSSL updated to the latest version
+- LuaJIT updated to 2.1-20190329
+- Updated BoringSSL patch for compatibility with the latest version
+
 * Thu Feb 28 2019 Anton Novojilov <andy@essentialkaos.com> - 1.15.9-0
 - Nginx updated to 1.15.9
 - LuaJIT replaced by OpenResty's fork


### PR DESCRIPTION
#### Improvements
- Nginx updated to 1.15.10
- BoringSSL updated to the latest version
- LuaJIT updated to 2.1-20190329
- Updated BoringSSL patch for compatibility with the latest version
