### PR TITLE
Version 1.17.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,11 @@ env:
 before_install:
   - docker pull "$IMAGE"
   - wget https://raw.githubusercontent.com/essentialkaos/perfecto/master/perfecto-docker
-  - chmod +x perfecto-docker
+  - wget -O hadolint https://github.com/hadolint/hadolint/releases/download/v1.17.2/hadolint-Linux-x86_64
+  - chmod +x perfecto-docker hadolint
+  - ./hadolint --version
 
 script:
   - ./perfecto-docker webkaos.spec
+  - ./hadolint centos6.docker
+  - ./hadolint centos7.docker

--- a/SOURCES/boringssl-tls13-support.patch
+++ b/SOURCES/boringssl-tls13-support.patch
@@ -1,7 +1,7 @@
 diff -urN boringssl-orig/ssl/s3_lib.cc boringssl/ssl/s3_lib.cc
---- boringssl-orig/ssl/s3_lib.cc	2019-04-09 00:27:58.157453794 +0300
-+++ boringssl/ssl/s3_lib.cc	2019-04-09 00:29:57.000000000 +0300
-@@ -202,7 +202,7 @@
+--- boringssl-orig/ssl/s3_lib.cc	2019-11-08 14:59:18.000000000 +0300
++++ boringssl/ssl/s3_lib.cc	2019-11-08 17:43:59.000000000 +0300
+@@ -206,7 +206,7 @@
    // TODO(davidben): Move this field into |s3|, have it store the normalized
    // protocol version, and implement this pre-negotiation quirk in |SSL_version|
    // at the API boundary rather than in internal state.
@@ -9,16 +9,4 @@ diff -urN boringssl-orig/ssl/s3_lib.cc boringssl/ssl/s3_lib.cc
 +  ssl->version = TLS1_3_VERSION;
    return true;
  }
- 
-diff -urN boringssl-orig/ssl/ssl_versions.cc boringssl/ssl/ssl_versions.cc
---- boringssl-orig/ssl/ssl_versions.cc	2019-04-09 00:27:58.158453785 +0300
-+++ boringssl/ssl/ssl_versions.cc	2019-04-09 00:41:47.000000000 +0300
-@@ -158,7 +158,7 @@
-                             uint16_t version) {
-   // Zero is interpreted as the default maximum version.
-   if (version == 0) {
--    *out = method->is_dtls ? DTLS1_2_VERSION : TLS1_2_VERSION;
-+    *out = method->is_dtls ? DTLS1_2_VERSION : TLS1_3_VERSION;
-     return true;
-   }
  

--- a/SOURCES/boringssl-urand-test-disable.patch
+++ b/SOURCES/boringssl-urand-test-disable.patch
@@ -1,0 +1,24 @@
+diff -urN boringssl-orig/crypto/CMakeLists.txt boringssl/crypto/CMakeLists.txt
+--- boringssl-orig/crypto/CMakeLists.txt	2019-11-08 14:59:15.000000000 +0300
++++ boringssl/crypto/CMakeLists.txt	2019-11-08 18:19:21.000000000 +0300
+@@ -453,20 +453,6 @@
+   target_link_libraries(crypto libcxx)
+ endif()
+ 
+-# urandom_test is a separate binary because it needs to be able to observe the
+-# PRNG initialisation, which means that it can't have other tests running before
+-# it does.
+-add_executable(
+-  urandom_test
+-
+-  fipsmodule/rand/urandom_test.cc
+-)
+-
+-target_link_libraries(urandom_test test_support_lib boringssl_gtest crypto)
+-
+-add_dependencies(urandom_test global_target)
+-add_dependencies(all_tests urandom_test)
+-
+ add_executable(
+   crypto_test
+ 

--- a/SOURCES/webkaos.conf
+++ b/SOURCES/webkaos.conf
@@ -125,7 +125,6 @@ http {
   ssl_prefer_server_ciphers  on;
   ssl_dyn_rec_enable         on;
   ssl_protocols              TLSv1.1 TLSv1.2 TLSv1.3;
-  ssl_dhparam                /etc/webkaos/ssl/dhparam.pem;
 
   resolver                   1.1.1.1 8.8.8.8 valid=300s;
   resolver_timeout           10s;

--- a/SOURCES/webkaos.patch
+++ b/SOURCES/webkaos.patch
@@ -1,6 +1,6 @@
-diff -urN nginx-1.17.4-orig/auto/lib/openssl/make nginx-1.17.4/auto/lib/openssl/make
---- nginx-1.17.4-orig/auto/lib/openssl/make	2019-09-24 18:08:48.000000000 +0300
-+++ nginx-1.17.4/auto/lib/openssl/make	2019-09-25 00:52:11.846220618 +0300
+diff -urN nginx-1.17.5-orig/auto/lib/openssl/make nginx-1.17.5/auto/lib/openssl/make
+--- nginx-1.17.5-orig/auto/lib/openssl/make	2019-10-22 18:16:08.000000000 +0300
++++ nginx-1.17.5/auto/lib/openssl/make	2019-11-08 15:01:50.075606846 +0300
 @@ -45,18 +45,18 @@
              /*) ngx_prefix="$OPENSSL/.openssl" ;;
              *)  ngx_prefix="$PWD/$OPENSSL/.openssl" ;;
@@ -24,9 +24,9 @@ diff -urN nginx-1.17.4-orig/auto/lib/openssl/make nginx-1.17.4/auto/lib/openssl/
      ;;
  
  esac
-diff -urN nginx-1.17.4-orig/src/core/nginx.c nginx-1.17.4/src/core/nginx.c
---- nginx-1.17.4-orig/src/core/nginx.c	2019-09-24 18:08:48.000000000 +0300
-+++ nginx-1.17.4/src/core/nginx.c	2019-09-25 00:52:11.852220569 +0300
+diff -urN nginx-1.17.5-orig/src/core/nginx.c nginx-1.17.5/src/core/nginx.c
+--- nginx-1.17.5-orig/src/core/nginx.c	2019-10-22 18:16:08.000000000 +0300
++++ nginx-1.17.5/src/core/nginx.c	2019-11-08 15:01:50.081606793 +0300
 @@ -389,13 +389,13 @@
  static void
  ngx_show_version_info(void)
@@ -45,13 +45,13 @@ diff -urN nginx-1.17.4-orig/src/core/nginx.c nginx-1.17.4/src/core/nginx.c
              "Options:" NGX_LINEFEED
              "  -?,-h         : this help" NGX_LINEFEED
              "  -v            : show version and exit" NGX_LINEFEED
-diff -urN nginx-1.17.4-orig/src/core/nginx.h nginx-1.17.4/src/core/nginx.h
---- nginx-1.17.4-orig/src/core/nginx.h	2019-09-24 18:08:48.000000000 +0300
-+++ nginx-1.17.4/src/core/nginx.h	2019-09-25 00:53:54.000000000 +0300
+diff -urN nginx-1.17.5-orig/src/core/nginx.h nginx-1.17.5/src/core/nginx.h
+--- nginx-1.17.5-orig/src/core/nginx.h	2019-10-22 18:16:08.000000000 +0300
++++ nginx-1.17.5/src/core/nginx.h	2019-11-08 15:02:19.000000000 +0300
 @@ -11,7 +11,7 @@
  
- #define nginx_version      1017004
- #define NGINX_VERSION      "1.17.4"
+ #define nginx_version      1017005
+ #define NGINX_VERSION      "1.17.5"
 -#define NGINX_VER          "nginx/" NGINX_VERSION
 +#define NGINX_VER          "webkaos/" NGINX_VERSION
  
@@ -66,9 +66,9 @@ diff -urN nginx-1.17.4-orig/src/core/nginx.h nginx-1.17.4/src/core/nginx.h
  #define NGX_OLDPID_EXT     ".oldbin"
  
  
-diff -urN nginx-1.17.4-orig/src/core/ngx_log.c nginx-1.17.4/src/core/ngx_log.c
---- nginx-1.17.4-orig/src/core/ngx_log.c	2019-09-24 18:08:48.000000000 +0300
-+++ nginx-1.17.4/src/core/ngx_log.c	2019-09-25 00:52:11.862220487 +0300
+diff -urN nginx-1.17.5-orig/src/core/ngx_log.c nginx-1.17.5/src/core/ngx_log.c
+--- nginx-1.17.5-orig/src/core/ngx_log.c	2019-10-22 18:16:08.000000000 +0300
++++ nginx-1.17.5/src/core/ngx_log.c	2019-11-08 15:01:50.091606704 +0300
 @@ -202,9 +202,9 @@
          return;
      }
@@ -99,9 +99,9 @@ diff -urN nginx-1.17.4-orig/src/core/ngx_log.c nginx-1.17.4/src/core/ngx_log.c
          return NGX_CONF_ERROR;
  #endif
  
-diff -urN nginx-1.17.4-orig/src/http/modules/ngx_http_autoindex_module.c nginx-1.17.4/src/http/modules/ngx_http_autoindex_module.c
---- nginx-1.17.4-orig/src/http/modules/ngx_http_autoindex_module.c	2019-09-24 18:08:48.000000000 +0300
-+++ nginx-1.17.4/src/http/modules/ngx_http_autoindex_module.c	2019-09-25 00:52:11.868220438 +0300
+diff -urN nginx-1.17.5-orig/src/http/modules/ngx_http_autoindex_module.c nginx-1.17.5/src/http/modules/ngx_http_autoindex_module.c
+--- nginx-1.17.5-orig/src/http/modules/ngx_http_autoindex_module.c	2019-10-22 18:16:08.000000000 +0300
++++ nginx-1.17.5/src/http/modules/ngx_http_autoindex_module.c	2019-11-08 15:01:50.097606651 +0300
 @@ -449,9 +449,11 @@
      ;
  
@@ -177,9 +177,9 @@ diff -urN nginx-1.17.4-orig/src/http/modules/ngx_http_autoindex_module.c nginx-1
                                tm.ngx_tm_mday,
                                months[tm.ngx_tm_mon - 1],
                                tm.ngx_tm_year,
-diff -urN nginx-1.17.4-orig/src/http/ngx_http_header_filter_module.c nginx-1.17.4/src/http/ngx_http_header_filter_module.c
---- nginx-1.17.4-orig/src/http/ngx_http_header_filter_module.c	2019-09-24 18:08:48.000000000 +0300
-+++ nginx-1.17.4/src/http/ngx_http_header_filter_module.c	2019-09-25 00:52:11.873220397 +0300
+diff -urN nginx-1.17.5-orig/src/http/ngx_http_header_filter_module.c nginx-1.17.5/src/http/ngx_http_header_filter_module.c
+--- nginx-1.17.5-orig/src/http/ngx_http_header_filter_module.c	2019-10-22 18:16:08.000000000 +0300
++++ nginx-1.17.5/src/http/ngx_http_header_filter_module.c	2019-11-08 15:01:50.102606607 +0300
 @@ -46,7 +46,7 @@
  };
  
@@ -230,9 +230,9 @@ diff -urN nginx-1.17.4-orig/src/http/ngx_http_header_filter_module.c nginx-1.17.
  #define NGX_HTTP_OFF_5XX   (NGX_HTTP_LAST_4XX - 400 + NGX_HTTP_OFF_4XX)
  
      ngx_string("500 Internal Server Error"),
-diff -urN nginx-1.17.4-orig/src/http/ngx_http_special_response.c nginx-1.17.4/src/http/ngx_http_special_response.c
---- nginx-1.17.4-orig/src/http/ngx_http_special_response.c	2019-09-24 18:08:48.000000000 +0300
-+++ nginx-1.17.4/src/http/ngx_http_special_response.c	2019-09-25 00:52:11.879220348 +0300
+diff -urN nginx-1.17.5-orig/src/http/ngx_http_special_response.c nginx-1.17.5/src/http/ngx_http_special_response.c
+--- nginx-1.17.5-orig/src/http/ngx_http_special_response.c	2019-10-22 18:16:08.000000000 +0300
++++ nginx-1.17.5/src/http/ngx_http_special_response.c	2019-11-08 15:01:50.108606554 +0300
 @@ -19,21 +19,21 @@
  
  
@@ -705,9 +705,9 @@ diff -urN nginx-1.17.4-orig/src/http/ngx_http_special_response.c nginx-1.17.4/sr
  #define NGX_HTTP_OFF_5XX   (NGX_HTTP_LAST_4XX - 400 + NGX_HTTP_OFF_4XX)
  
      ngx_string(ngx_http_error_494_page), /* 494, request header too large */
-diff -urN nginx-1.17.4-orig/src/http/v2/ngx_http_v2_filter_module.c nginx-1.17.4/src/http/v2/ngx_http_v2_filter_module.c
---- nginx-1.17.4-orig/src/http/v2/ngx_http_v2_filter_module.c	2019-09-24 18:08:48.000000000 +0300
-+++ nginx-1.17.4/src/http/v2/ngx_http_v2_filter_module.c	2019-09-25 00:55:06.000000000 +0300
+diff -urN nginx-1.17.5-orig/src/http/v2/ngx_http_v2_filter_module.c nginx-1.17.5/src/http/v2/ngx_http_v2_filter_module.c
+--- nginx-1.17.5-orig/src/http/v2/ngx_http_v2_filter_module.c	2019-10-22 18:16:08.000000000 +0300
++++ nginx-1.17.5/src/http/v2/ngx_http_v2_filter_module.c	2019-11-08 15:01:50.114606501 +0300
 @@ -148,7 +148,7 @@
      ngx_http_core_srv_conf_t  *cscf;
      u_char                     addr[NGX_SOCKADDR_STRLEN];
@@ -726,9 +726,9 @@ diff -urN nginx-1.17.4-orig/src/http/v2/ngx_http_v2_filter_module.c nginx-1.17.4
          }
  
          *pos++ = ngx_http_v2_inc_indexed(NGX_HTTP_V2_SERVER_INDEX);
-diff -urN nginx-1.17.4-orig/src/os/unix/ngx_setproctitle.c nginx-1.17.4/src/os/unix/ngx_setproctitle.c
---- nginx-1.17.4-orig/src/os/unix/ngx_setproctitle.c	2019-09-24 18:08:48.000000000 +0300
-+++ nginx-1.17.4/src/os/unix/ngx_setproctitle.c	2019-09-25 00:52:11.889220266 +0300
+diff -urN nginx-1.17.5-orig/src/os/unix/ngx_setproctitle.c nginx-1.17.5/src/os/unix/ngx_setproctitle.c
+--- nginx-1.17.5-orig/src/os/unix/ngx_setproctitle.c	2019-10-22 18:16:08.000000000 +0300
++++ nginx-1.17.5/src/os/unix/ngx_setproctitle.c	2019-11-08 15:01:50.119606456 +0300
 @@ -89,7 +89,7 @@
  
      ngx_os_argv[1] = NULL;

--- a/centos6.docker
+++ b/centos6.docker
@@ -1,0 +1,26 @@
+## WEBKAOS IMAGE ###############################################################
+
+FROM centos:6
+
+ENV WK_VERSION 1.17.5
+
+LABEL name="WEBKAOS Image on CentOS 6" \
+      vendor="ESSENTIAL KAOS" \
+      maintainer="Anton Novojilov" \
+      license="EKOL" \
+      version="2019.11.08"
+
+RUN yum -y -q install https://yum.kaos.st/kaos-repo-latest.el6.noarch.rpm && \
+    yum -y -q install webkaos-${WK_VERSION} webkaos-module-brotli && \
+    rm -rf /var/cache/yum
+
+RUN ln -sf /dev/stdout /var/log/webkaos/access.log \
+    && ln -sf /dev/stderr /var/log/webkaos/error.log
+
+EXPOSE 80
+
+STOPSIGNAL SIGTERM
+
+CMD ["webkaos", "-g", "daemon off;"]
+
+################################################################################

--- a/centos7.docker
+++ b/centos7.docker
@@ -1,0 +1,26 @@
+## WEBKAOS IMAGE ###############################################################
+
+FROM centos:7
+
+ENV WK_VERSION 1.17.5
+
+LABEL name="WEBKAOS Image on CentOS 7" \
+      vendor="ESSENTIAL KAOS" \
+      maintainer="Anton Novojilov" \
+      license="EKOL" \
+      version="2019.11.08"
+
+RUN yum -y -q install https://yum.kaos.st/kaos-repo-latest.el7.noarch.rpm && \
+    yum -y -q install webkaos-${WK_VERSION} webkaos-module-brotli && \
+    rm -rf /var/cache/yum
+
+RUN ln -sf /dev/stdout /var/log/webkaos/access.log \
+    && ln -sf /dev/stderr /var/log/webkaos/error.log
+
+EXPOSE 80
+
+STOPSIGNAL SIGTERM
+
+CMD ["webkaos", "-g", "daemon off;"]
+
+################################################################################

--- a/webkaos.spec
+++ b/webkaos.spec
@@ -48,8 +48,8 @@
 %define service_name         %{name}
 %define service_home         %{_cachedir}/%{service_name}
 
-%define nginx_version        1.17.4
-%define boring_commit        1f1af82f409cd05450b3491865af0c770830cd76
+%define nginx_version        1.17.5
+%define boring_commit        43890dbd693d5d972afbc676860e5adf4a44236a
 %define lua_module_ver       0.10.15
 %define mh_module_ver        0.33
 %define pcre_ver             8.43
@@ -64,7 +64,7 @@
 Summary:              Superb high performance web server
 Name:                 webkaos
 Version:              %{nginx_version}
-Release:              1%{?dist}
+Release:              0%{?dist}
 License:              2-clause BSD-like license
 Group:                System Environment/Daemons
 URL:                  https://github.com/essentialkaos/webkaos
@@ -108,6 +108,7 @@ Patch5:               boringssl-tls13-support.patch
 Patch6:               boringssl-c6-build-fix.patch
 # For resty-core, lua-nginx-module 0.10.16 is required but it not released yet
 Patch7:               resty-core-disable.patch
+Patch8:               boringssl-urand-test-disable.patch
 
 BuildRoot:            %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
@@ -169,7 +170,7 @@ Links for nginx compatibility.
 
 Summary:           Module for Brotli compression
 Version:           0.1.3
-Release:           1%{?dist}
+Release:           2%{?dist}
 
 Group:             System Environment/Daemons
 Requires:          %{name} = %{nginx_version}
@@ -183,7 +184,7 @@ Module for Brotli compression.
 
 Summary:           High performance, low rules maintenance WAF
 Version:           %{naxsi_ver}
-Release:           1%{?dist}
+Release:           2%{?dist}
 
 Group:             System Environment/Daemons
 Requires:          %{name} = %{nginx_version}
@@ -217,6 +218,7 @@ tar xzvf %{SOURCE58}
 
 pushd boringssl
 %patch5 -p1
+%patch8 -p1
 %if 0%{?rhel} == 6
 %patch6 -p1
 %endif
@@ -694,6 +696,11 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Fri Nov 08 2019 Anton Novojilov <andy@essentialkaos.com> - 1.17.5-0
+- Nginx updated to 1.17.5
+- BoringSSL updated to the latest version
+- Removed ssl_dhparam from default configuration
+
 * Fri Nov 08 2019 Anton Novojilov <andy@essentialkaos.com> - 1.17.4-1
 - Added webserver to Provides
 


### PR DESCRIPTION
#### New Features
- Added docker files for CentOS 6 and 7

#### Improvements
- Nginx updated to `1.17.5`
- BoringSSL updated to the latest version
- Removed ssl_dhparam from the default configuration
