### PR TITLE
Version 1.21.0

### DIFF
--- a/SOURCES/webkaos.patch
+++ b/SOURCES/webkaos.patch
@@ -1,6 +1,6 @@
-diff -urN nginx-1.19.9-orig/auto/lib/openssl/make nginx-1.19.9/auto/lib/openssl/make
---- nginx-1.19.9-orig/auto/lib/openssl/make	2021-03-30 17:47:11.000000000 +0300
-+++ nginx-1.19.9/auto/lib/openssl/make	2021-04-07 01:07:50.778251918 +0300
+diff -urN nginx-1.21.0-orig/auto/lib/openssl/make nginx-1.21.0/auto/lib/openssl/make
+--- nginx-1.21.0-orig/auto/lib/openssl/make	2021-05-25 15:28:56.000000000 +0300
++++ nginx-1.21.0/auto/lib/openssl/make	2021-05-26 00:20:19.814580850 +0300
 @@ -45,18 +45,18 @@
              /*) ngx_prefix="$OPENSSL/.openssl" ;;
              *)  ngx_prefix="$PWD/$OPENSSL/.openssl" ;;
@@ -24,9 +24,9 @@ diff -urN nginx-1.19.9-orig/auto/lib/openssl/make nginx-1.19.9/auto/lib/openssl/
      ;;
  
  esac
-diff -urN nginx-1.19.9-orig/src/core/nginx.c nginx-1.19.9/src/core/nginx.c
---- nginx-1.19.9-orig/src/core/nginx.c	2021-03-30 17:47:11.000000000 +0300
-+++ nginx-1.19.9/src/core/nginx.c	2021-04-07 01:07:50.784251862 +0300
+diff -urN nginx-1.21.0-orig/src/core/nginx.c nginx-1.21.0/src/core/nginx.c
+--- nginx-1.21.0-orig/src/core/nginx.c	2021-05-25 15:28:56.000000000 +0300
++++ nginx-1.21.0/src/core/nginx.c	2021-05-26 00:20:19.820580797 +0300
 @@ -390,13 +390,13 @@
  static void
  ngx_show_version_info(void)
@@ -45,13 +45,13 @@ diff -urN nginx-1.19.9-orig/src/core/nginx.c nginx-1.19.9/src/core/nginx.c
              "Options:" NGX_LINEFEED
              "  -?,-h         : this help" NGX_LINEFEED
              "  -v            : show version and exit" NGX_LINEFEED
-diff -urN nginx-1.19.9-orig/src/core/nginx.h nginx-1.19.9/src/core/nginx.h
---- nginx-1.19.9-orig/src/core/nginx.h	2021-03-30 17:47:11.000000000 +0300
-+++ nginx-1.19.9/src/core/nginx.h	2021-04-07 01:08:58.000000000 +0300
+diff -urN nginx-1.21.0-orig/src/core/nginx.h nginx-1.21.0/src/core/nginx.h
+--- nginx-1.21.0-orig/src/core/nginx.h	2021-05-25 15:28:56.000000000 +0300
++++ nginx-1.21.0/src/core/nginx.h	2021-05-26 00:20:57.000000000 +0300
 @@ -11,7 +11,7 @@
  
- #define nginx_version      1019009
- #define NGINX_VERSION      "1.19.9"
+ #define nginx_version      1021000
+ #define NGINX_VERSION      "1.21.0"
 -#define NGINX_VER          "nginx/" NGINX_VERSION
 +#define NGINX_VER          "webkaos/" NGINX_VERSION
  
@@ -66,9 +66,9 @@ diff -urN nginx-1.19.9-orig/src/core/nginx.h nginx-1.19.9/src/core/nginx.h
  #define NGX_OLDPID_EXT     ".oldbin"
  
  
-diff -urN nginx-1.19.9-orig/src/core/ngx_log.c nginx-1.19.9/src/core/ngx_log.c
---- nginx-1.19.9-orig/src/core/ngx_log.c	2021-03-30 17:47:11.000000000 +0300
-+++ nginx-1.19.9/src/core/ngx_log.c	2021-04-07 01:07:50.794251769 +0300
+diff -urN nginx-1.21.0-orig/src/core/ngx_log.c nginx-1.21.0/src/core/ngx_log.c
+--- nginx-1.21.0-orig/src/core/ngx_log.c	2021-05-25 15:28:56.000000000 +0300
++++ nginx-1.21.0/src/core/ngx_log.c	2021-05-26 00:20:19.831580699 +0300
 @@ -202,9 +202,9 @@
          return;
      }
@@ -99,9 +99,9 @@ diff -urN nginx-1.19.9-orig/src/core/ngx_log.c nginx-1.19.9/src/core/ngx_log.c
          return NGX_CONF_ERROR;
  #endif
  
-diff -urN nginx-1.19.9-orig/src/http/modules/ngx_http_autoindex_module.c nginx-1.19.9/src/http/modules/ngx_http_autoindex_module.c
---- nginx-1.19.9-orig/src/http/modules/ngx_http_autoindex_module.c	2021-03-30 17:47:11.000000000 +0300
-+++ nginx-1.19.9/src/http/modules/ngx_http_autoindex_module.c	2021-04-07 01:16:18.000000000 +0300
+diff -urN nginx-1.21.0-orig/src/http/modules/ngx_http_autoindex_module.c nginx-1.21.0/src/http/modules/ngx_http_autoindex_module.c
+--- nginx-1.21.0-orig/src/http/modules/ngx_http_autoindex_module.c	2021-05-25 15:28:56.000000000 +0300
++++ nginx-1.21.0/src/http/modules/ngx_http_autoindex_module.c	2021-05-26 00:20:19.837580645 +0300
 @@ -449,9 +449,11 @@
      ;
  
@@ -177,9 +177,9 @@ diff -urN nginx-1.19.9-orig/src/http/modules/ngx_http_autoindex_module.c nginx-1
                                tm.ngx_tm_mday,
                                months[tm.ngx_tm_mon - 1],
                                tm.ngx_tm_year,
-diff -urN nginx-1.19.9-orig/src/http/ngx_http_header_filter_module.c nginx-1.19.9/src/http/ngx_http_header_filter_module.c
---- nginx-1.19.9-orig/src/http/ngx_http_header_filter_module.c	2021-03-30 17:47:11.000000000 +0300
-+++ nginx-1.19.9/src/http/ngx_http_header_filter_module.c	2021-04-07 01:07:50.806251657 +0300
+diff -urN nginx-1.21.0-orig/src/http/ngx_http_header_filter_module.c nginx-1.21.0/src/http/ngx_http_header_filter_module.c
+--- nginx-1.21.0-orig/src/http/ngx_http_header_filter_module.c	2021-05-25 15:28:56.000000000 +0300
++++ nginx-1.21.0/src/http/ngx_http_header_filter_module.c	2021-05-26 00:20:19.843580592 +0300
 @@ -46,7 +46,7 @@
  };
  
@@ -230,9 +230,9 @@ diff -urN nginx-1.19.9-orig/src/http/ngx_http_header_filter_module.c nginx-1.19.
  #define NGX_HTTP_OFF_5XX   (NGX_HTTP_LAST_4XX - 400 + NGX_HTTP_OFF_4XX)
  
      ngx_string("500 Internal Server Error"),
-diff -urN nginx-1.19.9-orig/src/http/ngx_http_special_response.c nginx-1.19.9/src/http/ngx_http_special_response.c
---- nginx-1.19.9-orig/src/http/ngx_http_special_response.c	2021-03-30 17:47:11.000000000 +0300
-+++ nginx-1.19.9/src/http/ngx_http_special_response.c	2021-04-07 01:07:50.812251601 +0300
+diff -urN nginx-1.21.0-orig/src/http/ngx_http_special_response.c nginx-1.21.0/src/http/ngx_http_special_response.c
+--- nginx-1.21.0-orig/src/http/ngx_http_special_response.c	2021-05-25 15:28:56.000000000 +0300
++++ nginx-1.21.0/src/http/ngx_http_special_response.c	2021-05-26 00:20:19.850580529 +0300
 @@ -19,21 +19,21 @@
  
  
@@ -705,9 +705,9 @@ diff -urN nginx-1.19.9-orig/src/http/ngx_http_special_response.c nginx-1.19.9/sr
  #define NGX_HTTP_OFF_5XX   (NGX_HTTP_LAST_4XX - 400 + NGX_HTTP_OFF_4XX)
  
      ngx_string(ngx_http_error_494_page), /* 494, request header too large */
-diff -urN nginx-1.19.9-orig/src/http/v2/ngx_http_v2_filter_module.c nginx-1.19.9/src/http/v2/ngx_http_v2_filter_module.c
---- nginx-1.19.9-orig/src/http/v2/ngx_http_v2_filter_module.c	2021-03-30 17:47:11.000000000 +0300
-+++ nginx-1.19.9/src/http/v2/ngx_http_v2_filter_module.c	2021-04-07 01:07:50.818251545 +0300
+diff -urN nginx-1.21.0-orig/src/http/v2/ngx_http_v2_filter_module.c nginx-1.21.0/src/http/v2/ngx_http_v2_filter_module.c
+--- nginx-1.21.0-orig/src/http/v2/ngx_http_v2_filter_module.c	2021-05-25 15:28:56.000000000 +0300
++++ nginx-1.21.0/src/http/v2/ngx_http_v2_filter_module.c	2021-05-26 00:20:19.856580476 +0300
 @@ -148,7 +148,7 @@
      ngx_http_core_srv_conf_t  *cscf;
      u_char                     addr[NGX_SOCKADDR_STRLEN];
@@ -726,9 +726,9 @@ diff -urN nginx-1.19.9-orig/src/http/v2/ngx_http_v2_filter_module.c nginx-1.19.9
          }
  
          *pos++ = ngx_http_v2_inc_indexed(NGX_HTTP_V2_SERVER_INDEX);
-diff -urN nginx-1.19.9-orig/src/os/unix/ngx_setproctitle.c nginx-1.19.9/src/os/unix/ngx_setproctitle.c
---- nginx-1.19.9-orig/src/os/unix/ngx_setproctitle.c	2021-03-30 17:47:11.000000000 +0300
-+++ nginx-1.19.9/src/os/unix/ngx_setproctitle.c	2021-04-07 01:07:50.823251499 +0300
+diff -urN nginx-1.21.0-orig/src/os/unix/ngx_setproctitle.c nginx-1.21.0/src/os/unix/ngx_setproctitle.c
+--- nginx-1.21.0-orig/src/os/unix/ngx_setproctitle.c	2021-05-25 15:28:56.000000000 +0300
++++ nginx-1.21.0/src/os/unix/ngx_setproctitle.c	2021-05-26 00:20:19.862580422 +0300
 @@ -89,7 +89,7 @@
  
      ngx_os_argv[1] = NULL;

--- a/webkaos.spec
+++ b/webkaos.spec
@@ -52,15 +52,15 @@
 %define service_name         %{name}
 %define service_home         %{_cachedir}/%{service_name}
 
-%define nginx_version        1.19.9
-%define boring_commit        fa2d3d56b9f542f8519b1c2298213d92eb954f3c
+%define nginx_version        1.21.0
+%define boring_commit        4749d8fb89ba5d765e0afa1799805b5096cb337b
 %define lua_module_ver       0.10.19
 %define lua_resty_core_ver   0.1.21
 %define lua_resty_lru_ver    0.10
 %define mh_module_ver        0.33
 %define pcre_ver             8.44
 %define zlib_ver             1.2.11
-%define luajit_ver           2.1-20201229
+%define luajit_ver           2.1-20210510
 %define luajit_raw_ver       2.1.0-beta3
 %define brotli_commit        9aec15e2aa6feea2113119ba06460af70ab3ea62
 %define brotli_ver           1.0.9
@@ -168,7 +168,7 @@ Links for nginx compatibility.
 
 Summary:           Module for Brotli compression
 Version:           0.1.5
-Release:           4%{?dist}
+Release:           5%{?dist}
 
 Group:             System Environment/Daemons
 Requires:          %{name} = %{nginx_version}
@@ -182,7 +182,7 @@ Module for Brotli compression.
 
 Summary:           High performance, low rules maintenance WAF
 Version:           %{naxsi_ver}
-Release:           3%{?dist}
+Release:           4%{?dist}
 
 Group:             System Environment/Daemons
 Requires:          %{name} = %{nginx_version}
@@ -667,6 +667,11 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Wed May 26 2021 Anton Novojilov <andy@essentialkaos.com> - 1.21.0-0
+- Nginx updated to 1.21.0 with fix for CVE-2021-23017
+- BoringSSL updated to the latest version
+- LuaJIT updated to 2.1-20210510
+
 * Wed Apr 07 2021 Anton Novojilov <andy@essentialkaos.com> - 1.19.9-0
 - Nginx updated to 1.19.9
 - BoringSSL updated to the latest version


### PR DESCRIPTION
#### Improvements
- Nginx updated to `1.21.0` with fix for [CVE-2021-23017](http://mailman.nginx.org/pipermail/nginx-announce/2021/000300.html)
- BoringSSL updated to the latest version
- LuaJIT updated to `2.1-20210510`
