### PR TITLE
Version 1.23.0

### DIFF
--- a/.bibop/webkaos.conf
+++ b/.bibop/webkaos.conf
@@ -108,4 +108,5 @@ http {
   }
 
   include conf.d/*.conf;
+  include xtra/brotli.conf;
 }

--- a/.bibop/webkaos.conf
+++ b/.bibop/webkaos.conf
@@ -82,6 +82,11 @@ http {
       root /usr/share/webkaos/html;
     }
 
+    location /mh {
+      more_set_headers "Server: bibop";
+      return 200;
+    }
+
     location /lua {
       content_by_lua_block {
         ngx.say("LUA MODULE WORKS")
@@ -98,6 +103,11 @@ http {
 
     location / {
       root /usr/share/webkaos/html;
+    }
+
+    location /mh {
+      more_set_headers "Server: bibop";
+      return 200;
     }
 
     location /lua {

--- a/.bibop/webkaos.recipe
+++ b/.bibop/webkaos.recipe
@@ -166,22 +166,22 @@ command "systemctl start {service_name}" "Start service"
   service-works {service_name}
 
 command "-" "Make HTTP requests"
+  http-set-header Accept-Encoding "gzip, deflate, br"
   http-status GET "http://127.0.0.1" 200
   http-header GET "http://127.0.0.1" server webkaos
+  http-header GET "http://127.0.0.1" Content-Encoding br
   http-contains GET "http://127.0.0.1/lua" "LUA MODULE WORKS"
   !empty {log_dir}/access.log
   truncate {log_dir}/access.log
 
 command "-" "Make HTTPS requests"
+  http-set-header Accept-Encoding "gzip, deflate, br"
   http-status GET "https://127.0.0.1" 200
   http-header GET "https://127.0.0.1" server webkaos
+  http-header GET "https://127.0.0.1" Content-Encoding br
   http-contains GET "https://127.0.0.1/lua" "LUA MODULE WORKS"
   !empty {log_dir}/access.log
   truncate {log_dir}/access.log
-
-command "-" "Check brotli compression"
-  http-set-header Accept-Encoding "gzip, deflate, br"
-  http-header GET "https://127.0.0.1" Content-Encoding br
 
 command "-" "Save PID file checksum"
   checksum-read {pid_file} pid_sha

--- a/.bibop/webkaos.recipe
+++ b/.bibop/webkaos.recipe
@@ -169,6 +169,7 @@ command "-" "Make HTTP requests"
   http-set-header Accept-Encoding "gzip, deflate, br"
   http-status GET "http://127.0.0.1" 200
   http-header GET "http://127.0.0.1" server webkaos
+  http-header GET "http://127.0.0.1/mh" server bibop
   http-header GET "http://127.0.0.1" Content-Encoding br
   http-contains GET "http://127.0.0.1/lua" "LUA MODULE WORKS"
   !empty {log_dir}/access.log
@@ -178,6 +179,7 @@ command "-" "Make HTTPS requests"
   http-set-header Accept-Encoding "gzip, deflate, br"
   http-status GET "https://127.0.0.1" 200
   http-header GET "https://127.0.0.1" server webkaos
+  http-header GET "https://127.0.0.1/mh" server bibop
   http-header GET "https://127.0.0.1" Content-Encoding br
   http-contains GET "https://127.0.0.1/lua" "LUA MODULE WORKS"
   !empty {log_dir}/access.log

--- a/.bibop/webkaos.recipe
+++ b/.bibop/webkaos.recipe
@@ -179,6 +179,10 @@ command "-" "Make HTTPS requests"
   !empty {log_dir}/access.log
   truncate {log_dir}/access.log
 
+command "-" "Check brotli compression"
+  http-set-header Accept-Encoding "gzip, deflate, br"
+  http-header GET "https://127.0.0.1" Content-Encoding br
+
 command "-" "Save PID file checksum"
   checksum-read {pid_file} pid_sha
 

--- a/SOURCES/headers-more-nginx-module-compat.patch
+++ b/SOURCES/headers-more-nginx-module-compat.patch
@@ -1,0 +1,19 @@
+diff -urN headers-more-nginx-module-0.33-orig/src/ngx_http_headers_more_headers_in.c headers-more-nginx-module-0.33/src/ngx_http_headers_more_headers_in.c
+--- headers-more-nginx-module-0.33-orig/src/ngx_http_headers_more_headers_in.c	2017-11-04 02:05:42.000000000 +0300
++++ headers-more-nginx-module-0.33/src/ngx_http_headers_more_headers_in.c	2022-07-04 14:37:27.000000000 +0300
+@@ -158,9 +158,15 @@
+                  ngx_http_set_builtin_header },
+ #endif
+ 
++#if defined(nginx_version) && nginx_version >= 1023000
++    { ngx_string("Cookie"),
++                 offsetof(ngx_http_headers_in_t, cookie),
++                 ngx_http_set_builtin_multi_header },
++#else
+     { ngx_string("Cookie"),
+                  offsetof(ngx_http_headers_in_t, cookies),
+                  ngx_http_set_builtin_multi_header },
++#endif
+ 
+     { ngx_null_string, 0, ngx_http_set_header }
+ };

--- a/SOURCES/lua-nginx-module-compat.patch
+++ b/SOURCES/lua-nginx-module-compat.patch
@@ -1,0 +1,19 @@
+diff -urN lua-nginx-module-0.10.21-orig/src/ngx_http_lua_headers_in.c lua-nginx-module-0.10.21/src/ngx_http_lua_headers_in.c
+--- lua-nginx-module-0.10.21-orig/src/ngx_http_lua_headers_in.c	2022-03-02 09:54:22.000000000 +0300
++++ lua-nginx-module-0.10.21/src/ngx_http_lua_headers_in.c	2022-07-04 14:32:05.000000000 +0300
+@@ -152,9 +152,15 @@
+                  ngx_http_set_builtin_header },
+ #endif
+ 
++#if defined(nginx_version) && nginx_version >= 1023000
++    { ngx_string("Cookie"),
++                 offsetof(ngx_http_headers_in_t, cookie),
++                 ngx_http_set_builtin_multi_header },
++#else
+     { ngx_string("Cookie"),
+                  offsetof(ngx_http_headers_in_t, cookies),
+                  ngx_http_set_builtin_multi_header },
++#endif
+ 
+     { ngx_null_string, 0, ngx_http_set_header }
+ };

--- a/SOURCES/naxsi-compat.patch
+++ b/SOURCES/naxsi-compat.patch
@@ -1,0 +1,115 @@
+diff -urN naxsi-1.3-orig/naxsi_src/naxsi.h naxsi-1.3/naxsi_src/naxsi.h
+--- naxsi-1.3-orig/naxsi_src/naxsi.h	2020-11-17 16:46:31.000000000 +0300
++++ naxsi-1.3/naxsi_src/naxsi.h	2022-07-04 14:59:17.000000000 +0300
+@@ -9,12 +9,12 @@
+ 
+ #define NAXSI_VERSION "1.3"
+ 
++#include <ngx_config.h>
++#include <ngx_core.h>
+ #include "ext/libinjection/libinjection_sqli.h"
+ #include "ext/libinjection/libinjection_xss.h"
+ #include <ctype.h>
+ #include <nginx.h>
+-#include <ngx_config.h>
+-#include <ngx_core.h>
+ #include <ngx_event.h>
+ #include <ngx_http.h>
+ #include <ngx_http_core_module.h>
+diff -urN naxsi-1.3-orig/naxsi_src/naxsi_runtime.c naxsi-1.3/naxsi_src/naxsi_runtime.c
+--- naxsi-1.3-orig/naxsi_src/naxsi_runtime.c	2020-11-17 16:46:31.000000000 +0300
++++ naxsi-1.3/naxsi_src/naxsi_runtime.c	2022-07-04 15:10:42.000000000 +0300
+@@ -4,8 +4,8 @@
+  * Licensed under GNU GPL v3.0 – See the LICENSE notice for details
+  */
+ 
+-#include "assert.h"
+ #include "naxsi.h"
++#include "assert.h"
+ #include "naxsi_macros.h"
+ #include "naxsi_net.h"
+ 
+@@ -2835,11 +2835,13 @@
+       /* and the presence of data to parse */
+       r->request_body && ((!ctx->block || ctx->learning) && !ctx->drop))
+     ngx_http_naxsi_body_parse(ctx, r, cf, main_cf);
++#if (NGX_HTTP_X_FORWARDED_FOR)
+   ngx_str_t tag;
+   tag.len  = 15;
+   tag.data = ngx_pcalloc(r->pool, tag.len + 1);
+   if (tag.data)
+     memcpy(tag.data, "x-forwarded-for", 15);
++#if (nginx_version < 1023000)
+   unsigned int      n = 0;
+   ngx_table_elt_t** h = NULL;
+   ngx_array_t       a;
+@@ -2854,6 +2856,16 @@
+ 
+     ngx_http_naxsi_update_current_ctx_status(ctx, cf, r, &tag, (ngx_str_t*)h[0]->value.data);
+   }
++#else
++  ngx_table_elt_t* xff = NULL;
++  if (r->headers_in.x_forwarded_for != NULL) {
++    xff = r->headers_in.x_forwarded_for;
++    ngx_log_debug(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "xfor %s", xff->value.data);
++
++    ngx_http_naxsi_update_current_ctx_status(ctx, cf, r, &tag, (ngx_str_t*)xff->value.data);
++  }
++#endif
++#endif
+ }
+ 
+ void
+@@ -2868,18 +2880,20 @@
+   ngx_http_check_rule_t* cr;
+ 
+   ngx_http_special_score_t* sc;
+-  unsigned int              n = 0;
+ 
+   NX_DEBUG(_debug_custom_score, NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "XX-custom check rules");
+ 
+-  int               ignore = 0;
+-  ngx_table_elt_t** h;
+-  ngx_array_t       a;
++  int ignore = 0;
+ 
+   ctx->ignore = 0;
+ 
+   /*cr, sc, cf, ctx*/
+   if (cf->check_rules && ctx->special_scores) {
++#if (NGX_HTTP_X_FORWARDED_FOR)
++#if (nginx_version < 1023000)
++      unsigned int  n = 0;
++      ngx_table_elt_t** h;
++      ngx_array_t       a;
+     if (r->headers_in.x_forwarded_for.nelts >= 1) {
+       a = r->headers_in.x_forwarded_for;
+       n = a.nelts;
+@@ -2897,7 +2911,26 @@
+         memcpy(ip.data, h[0]->value.data, ip.len);
+         ignore = nx_can_ignore_ip(&ip, cf) || nx_can_ignore_cidr(&ip, cf);
+       }
+-    } else {
++    } else
++#else
++    ngx_table_elt_t* xff;
++    if (r->headers_in.x_forwarded_for != NULL) {
++      xff = r->headers_in.x_forwarded_for;
++      NX_DEBUG(_debug_whitelist_ignore,
++                 NGX_LOG_DEBUG_HTTP,
++                 r->connection->log,
++                 0,
++                 "XX- lookup ignore X-Forwarded-For: %s",
++                 xff->value.data);
++      ngx_str_t ip;
++      ip.len  = strlen((char*)xff->value.data);
++      ip.data = ngx_pcalloc(r->pool, ip.len + 1);
++      memcpy(ip.data, xff->value.data, ip.len);
++      ignore = nx_can_ignore_ip(&ip, cf) || nx_can_ignore_cidr(&ip, cf);
++    } else
++#endif
++#endif
++      {
+       ngx_str_t* ip = &r->connection->addr_text;
+       NX_DEBUG(_debug_whitelist_ignore,
+                NGX_LOG_DEBUG_HTTP,

--- a/SOURCES/webkaos.patch
+++ b/SOURCES/webkaos.patch
@@ -1,6 +1,6 @@
-diff -urN nginx-1.21.6-orig/auto/lib/openssl/make nginx-1.21.6/auto/lib/openssl/make
---- nginx-1.21.6-orig/auto/lib/openssl/make	2022-01-25 18:03:52.000000000 +0300
-+++ nginx-1.21.6/auto/lib/openssl/make	2022-01-27 02:24:01.726472368 +0300
+diff -urN nginx-1.23.0-orig/auto/lib/openssl/make nginx-1.23.0/auto/lib/openssl/make
+--- nginx-1.23.0-orig/auto/lib/openssl/make	2022-06-21 17:25:37.000000000 +0300
++++ nginx-1.23.0/auto/lib/openssl/make	2022-07-04 12:51:02.001986904 +0300
 @@ -45,18 +45,18 @@
              /*) ngx_prefix="$OPENSSL/.openssl" ;;
              *)  ngx_prefix="$PWD/$OPENSSL/.openssl" ;;
@@ -24,9 +24,9 @@ diff -urN nginx-1.21.6-orig/auto/lib/openssl/make nginx-1.21.6/auto/lib/openssl/
      ;;
  
  esac
-diff -urN nginx-1.21.6-orig/src/core/nginx.c nginx-1.21.6/src/core/nginx.c
---- nginx-1.21.6-orig/src/core/nginx.c	2022-01-25 18:03:52.000000000 +0300
-+++ nginx-1.21.6/src/core/nginx.c	2022-01-27 02:24:01.732472318 +0300
+diff -urN nginx-1.23.0-orig/src/core/nginx.c nginx-1.23.0/src/core/nginx.c
+--- nginx-1.23.0-orig/src/core/nginx.c	2022-06-21 17:25:37.000000000 +0300
++++ nginx-1.23.0/src/core/nginx.c	2022-07-04 12:51:02.008986883 +0300
 @@ -390,13 +390,13 @@
  static void
  ngx_show_version_info(void)
@@ -45,13 +45,13 @@ diff -urN nginx-1.21.6-orig/src/core/nginx.c nginx-1.21.6/src/core/nginx.c
              "Options:" NGX_LINEFEED
              "  -?,-h         : this help" NGX_LINEFEED
              "  -v            : show version and exit" NGX_LINEFEED
-diff -urN nginx-1.21.6-orig/src/core/nginx.h nginx-1.21.6/src/core/nginx.h
---- nginx-1.21.6-orig/src/core/nginx.h	2022-01-25 18:03:52.000000000 +0300
-+++ nginx-1.21.6/src/core/nginx.h	2022-01-27 02:27:21.000000000 +0300
+diff -urN nginx-1.23.0-orig/src/core/nginx.h nginx-1.23.0/src/core/nginx.h
+--- nginx-1.23.0-orig/src/core/nginx.h	2022-06-21 17:25:37.000000000 +0300
++++ nginx-1.23.0/src/core/nginx.h	2022-07-04 12:51:53.000000000 +0300
 @@ -11,7 +11,7 @@
  
- #define nginx_version      1021006
- #define NGINX_VERSION      "1.21.6"
+ #define nginx_version      1023000
+ #define NGINX_VERSION      "1.23.0"
 -#define NGINX_VER          "nginx/" NGINX_VERSION
 +#define NGINX_VER          "webkaos/" NGINX_VERSION
  
@@ -66,9 +66,9 @@ diff -urN nginx-1.21.6-orig/src/core/nginx.h nginx-1.21.6/src/core/nginx.h
  #define NGX_OLDPID_EXT     ".oldbin"
  
  
-diff -urN nginx-1.21.6-orig/src/core/ngx_log.c nginx-1.21.6/src/core/ngx_log.c
---- nginx-1.21.6-orig/src/core/ngx_log.c	2022-01-25 18:03:52.000000000 +0300
-+++ nginx-1.21.6/src/core/ngx_log.c	2022-01-27 02:24:01.741472242 +0300
+diff -urN nginx-1.23.0-orig/src/core/ngx_log.c nginx-1.23.0/src/core/ngx_log.c
+--- nginx-1.23.0-orig/src/core/ngx_log.c	2022-06-21 17:25:37.000000000 +0300
++++ nginx-1.23.0/src/core/ngx_log.c	2022-07-04 12:51:02.019986851 +0300
 @@ -202,9 +202,9 @@
          return;
      }
@@ -99,9 +99,9 @@ diff -urN nginx-1.21.6-orig/src/core/ngx_log.c nginx-1.21.6/src/core/ngx_log.c
          return NGX_CONF_ERROR;
  #endif
  
-diff -urN nginx-1.21.6-orig/src/http/modules/ngx_http_autoindex_module.c nginx-1.21.6/src/http/modules/ngx_http_autoindex_module.c
---- nginx-1.21.6-orig/src/http/modules/ngx_http_autoindex_module.c	2022-01-25 18:03:52.000000000 +0300
-+++ nginx-1.21.6/src/http/modules/ngx_http_autoindex_module.c	2022-01-27 02:24:01.746472200 +0300
+diff -urN nginx-1.23.0-orig/src/http/modules/ngx_http_autoindex_module.c nginx-1.23.0/src/http/modules/ngx_http_autoindex_module.c
+--- nginx-1.23.0-orig/src/http/modules/ngx_http_autoindex_module.c	2022-06-21 17:25:37.000000000 +0300
++++ nginx-1.23.0/src/http/modules/ngx_http_autoindex_module.c	2022-07-04 12:51:02.025986833 +0300
 @@ -449,9 +449,11 @@
      ;
  
@@ -177,9 +177,9 @@ diff -urN nginx-1.21.6-orig/src/http/modules/ngx_http_autoindex_module.c nginx-1
                                tm.ngx_tm_mday,
                                months[tm.ngx_tm_mon - 1],
                                tm.ngx_tm_year,
-diff -urN nginx-1.21.6-orig/src/http/ngx_http_header_filter_module.c nginx-1.21.6/src/http/ngx_http_header_filter_module.c
---- nginx-1.21.6-orig/src/http/ngx_http_header_filter_module.c	2022-01-25 18:03:52.000000000 +0300
-+++ nginx-1.21.6/src/http/ngx_http_header_filter_module.c	2022-01-27 02:27:01.000000000 +0300
+diff -urN nginx-1.23.0-orig/src/http/ngx_http_header_filter_module.c nginx-1.23.0/src/http/ngx_http_header_filter_module.c
+--- nginx-1.23.0-orig/src/http/ngx_http_header_filter_module.c	2022-06-21 17:25:37.000000000 +0300
++++ nginx-1.23.0/src/http/ngx_http_header_filter_module.c	2022-07-04 12:51:02.032986812 +0300
 @@ -46,7 +46,7 @@
  };
  
@@ -230,9 +230,9 @@ diff -urN nginx-1.21.6-orig/src/http/ngx_http_header_filter_module.c nginx-1.21.
  #define NGX_HTTP_OFF_5XX   (NGX_HTTP_LAST_4XX - 400 + NGX_HTTP_OFF_4XX)
  
      ngx_string("500 Internal Server Error"),
-diff -urN nginx-1.21.6-orig/src/http/ngx_http_special_response.c nginx-1.21.6/src/http/ngx_http_special_response.c
---- nginx-1.21.6-orig/src/http/ngx_http_special_response.c	2022-01-25 18:03:52.000000000 +0300
-+++ nginx-1.21.6/src/http/ngx_http_special_response.c	2022-01-27 02:24:01.755472125 +0300
+diff -urN nginx-1.23.0-orig/src/http/ngx_http_special_response.c nginx-1.23.0/src/http/ngx_http_special_response.c
+--- nginx-1.23.0-orig/src/http/ngx_http_special_response.c	2022-06-21 17:25:37.000000000 +0300
++++ nginx-1.23.0/src/http/ngx_http_special_response.c	2022-07-04 12:54:24.000000000 +0300
 @@ -19,21 +19,21 @@
  
  
@@ -705,9 +705,9 @@ diff -urN nginx-1.21.6-orig/src/http/ngx_http_special_response.c nginx-1.21.6/sr
  #define NGX_HTTP_OFF_5XX   (NGX_HTTP_LAST_4XX - 400 + NGX_HTTP_OFF_4XX)
  
      ngx_string(ngx_http_error_494_page), /* 494, request header too large */
-diff -urN nginx-1.21.6-orig/src/http/v2/ngx_http_v2_filter_module.c nginx-1.21.6/src/http/v2/ngx_http_v2_filter_module.c
---- nginx-1.21.6-orig/src/http/v2/ngx_http_v2_filter_module.c	2022-01-25 18:03:52.000000000 +0300
-+++ nginx-1.21.6/src/http/v2/ngx_http_v2_filter_module.c	2022-01-27 02:24:01.761472074 +0300
+diff -urN nginx-1.23.0-orig/src/http/v2/ngx_http_v2_filter_module.c nginx-1.23.0/src/http/v2/ngx_http_v2_filter_module.c
+--- nginx-1.23.0-orig/src/http/v2/ngx_http_v2_filter_module.c	2022-06-21 17:25:37.000000000 +0300
++++ nginx-1.23.0/src/http/v2/ngx_http_v2_filter_module.c	2022-07-04 12:55:28.000000000 +0300
 @@ -148,7 +148,7 @@
      ngx_http_core_srv_conf_t  *cscf;
      u_char                     addr[NGX_SOCKADDR_STRLEN];
@@ -726,9 +726,9 @@ diff -urN nginx-1.21.6-orig/src/http/v2/ngx_http_v2_filter_module.c nginx-1.21.6
          }
  
          *pos++ = ngx_http_v2_inc_indexed(NGX_HTTP_V2_SERVER_INDEX);
-diff -urN nginx-1.21.6-orig/src/os/unix/ngx_setproctitle.c nginx-1.21.6/src/os/unix/ngx_setproctitle.c
---- nginx-1.21.6-orig/src/os/unix/ngx_setproctitle.c	2022-01-25 18:03:52.000000000 +0300
-+++ nginx-1.21.6/src/os/unix/ngx_setproctitle.c	2022-01-27 02:24:01.766472032 +0300
+diff -urN nginx-1.23.0-orig/src/os/unix/ngx_setproctitle.c nginx-1.23.0/src/os/unix/ngx_setproctitle.c
+--- nginx-1.23.0-orig/src/os/unix/ngx_setproctitle.c	2022-06-21 17:25:37.000000000 +0300
++++ nginx-1.23.0/src/os/unix/ngx_setproctitle.c	2022-07-04 12:51:02.047986768 +0300
 @@ -89,7 +89,7 @@
  
      ngx_os_argv[1] = NULL;

--- a/webkaos.spec
+++ b/webkaos.spec
@@ -52,15 +52,15 @@
 %define service_name         %{name}
 %define service_home         %{_cachedir}/%{service_name}
 
-%define nginx_version        1.21.6
-%define boring_commit        3a667d10e94186fd503966f5638e134fe9fb4080
-%define lua_module_ver       0.10.20
-%define lua_resty_core_ver   0.1.22
-%define lua_resty_lru_ver    0.11
+%define nginx_version        1.23.0
+%define boring_commit        c239ffd0552179f358de31517391679e9b62ccd3
+%define lua_module_ver       0.10.21
+%define lua_resty_core_ver   0.1.23
+%define lua_resty_lru_ver    0.13
 %define mh_module_ver        0.33
 %define pcre_ver             8.45
 %define zlib_ver             1.2.11
-%define luajit_ver           2.1-20220111
+%define luajit_ver           2.1-20220411
 %define luajit_raw_ver       2.1.0-beta3
 %define brotli_commit        9aec15e2aa6feea2113119ba06460af70ab3ea62
 %define brotli_ver           1.0.9
@@ -111,17 +111,21 @@ Source100:            checksum.sha512
 
 Patch0:               %{name}.patch
 Patch1:               mime.patch
-# https://github.com/cloudflare/sslconfig/blob/master/patches/nginx__1.11.5_dynamic_tls_records.patch
+                      # https://github.com/cloudflare/sslconfig/blob/master/patches/nginx__1.11.5_dynamic_tls_records.patch
 Patch2:               %{name}-dynamic-tls-records.patch
-# https://github.com/ajhaydock/BoringNginx/blob/master/patches
+                      # https://github.com/ajhaydock/BoringNginx/blob/master/patches
 Patch3:               boringssl.patch
 Patch5:               boringssl-tls13-support.patch
 Patch8:               boringssl-urand-test-disable.patch
 
+Patch10:              headers-more-nginx-module-compat.patch
+Patch11:              lua-nginx-module-compat.patch
+Patch12:              naxsi-compat.patch
+
 BuildRoot:            %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:        make perl cmake3 golang
-BuildRequires:        devtoolset-7-gcc-c++ devtoolset-7-binutils
+BuildRequires:        devtoolset-9-gcc-c++ devtoolset-9-binutils
 
 Requires:             initscripts >= 8.36 kaosv >= 2.16
 Requires:             gd libXpm libxslt
@@ -170,7 +174,7 @@ Links for nginx compatibility.
 
 Summary:           Module for Brotli compression
 Version:           0.1.5
-Release:           9%{?dist}
+Release:           10%{?dist}
 
 Group:             System Environment/Daemons
 Requires:          %{name} = %{nginx_version}
@@ -184,7 +188,7 @@ Module for Brotli compression.
 
 Summary:           High performance, low rules maintenance WAF
 Version:           %{naxsi_ver}
-Release:           8%{?dist}
+Release:           9%{?dist}
 
 Group:             System Environment/Daemons
 Requires:          %{name} = %{nginx_version}
@@ -223,6 +227,18 @@ pushd boringssl
 %patch8 -p1
 popd
 
+pushd headers-more-nginx-module-%{mh_module_ver}
+%patch10 -p1
+popd
+
+pushd lua-nginx-module-%{lua_module_ver}
+%patch11 -p1
+popd
+
+pushd naxsi-%{naxsi_ver}
+%patch12 -p1
+popd
+
 %build
 
 # Renaming and moving docs
@@ -234,8 +250,8 @@ mv README     NGINX-README
 mv lua-nginx-module-%{lua_module_ver}/README.markdown ./LUA-MODULE-README.markdown
 mv headers-more-nginx-module-%{mh_module_ver}/README.markdown ./HEADERS-MORE-MODULE-README.markdown
 
-# Use gcc and gcc-c++ from DevToolSet 7
-export PATH="/opt/rh/devtoolset-7/root/usr/bin:$PATH"
+# Use gcc and gcc-c++ from DevToolSet 9
+export PATH="/opt/rh/devtoolset-9/root/usr/bin:$PATH"
 
 # LuaJIT2 Build ################################################################
 
@@ -677,6 +693,15 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Mon Jul 04 2022 Anton Novojilov <andy@essentialkaos.com> - 1.23.0-0
+- Nginx updated to 1.23.0
+- BoringSSL updated to the latest stable version
+- LuaJIT updated to 2.1-20220411
+- lua-nginx-module updated to 0.10.21
+- lua-resty-core updated to 0.1.23
+- lua-resty-lru updated to 0.13
+- Using GCC 9 for build
+
 * Thu Jan 27 2022 Anton Novojilov <andy@essentialkaos.com> - 1.21.6-0
 - Nginx updated to 1.21.6
 - LuaJIT updated to 2.1-20220111


### PR DESCRIPTION
#### Improvements
- Nginx updated to `1.23.0`
- BoringSSL updated to the latest stable version
- LuaJIT updated to `2.1-20220411`
- lua-nginx-module updated to `0.10.21`
- lua-resty-core updated to `0.1.23`
- lua-resty-lru updated to `0.13`
- Using GCC 9 for build