### PR TITLE
Version 1.26.2

### DIFF
--- a/.bibop/webkaos.recipe
+++ b/.bibop/webkaos.recipe
@@ -122,13 +122,11 @@ command "-" "Check Resty core and lrucache"
 
 command "-" "Check extra configs"
   exist {extra_config_dir}/bots.conf
-  exist {extra_config_dir}/brotli.conf
   exist {extra_config_dir}/common.conf
   exist {extra_config_dir}/ssl.conf
   exist {extra_config_dir}/ssl-wildcard.conf
 
   mode {extra_config_dir}/bots.conf 644
-  mode {extra_config_dir}/brotli.conf 644
   mode {extra_config_dir}/common.conf 644
   mode {extra_config_dir}/ssl.conf 644
   mode {extra_config_dir}/ssl-wildcard.conf 644

--- a/.docker/ol8-unprivileged.docker
+++ b/.docker/ol8-unprivileged.docker
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.title="WEBKAOS (Unprivileged)" \
       org.opencontainers.image.url="https://kaos.sh/webkaos" \
       org.opencontainers.image.source="https://github.com/essentialkaos/webkaos"
 
-ARG WEBKAOS_VER=1.26.1
+ARG WEBKAOS_VER=1.26.2
 ARG REPOSITORY=kaos-release
 
 ARG UID=1001

--- a/.docker/ol8-unprivileged.docker
+++ b/.docker/ol8-unprivileged.docker
@@ -14,8 +14,7 @@ LABEL org.opencontainers.image.title="WEBKAOS (Unprivileged)" \
       org.opencontainers.image.url="https://kaos.sh/webkaos" \
       org.opencontainers.image.source="https://github.com/essentialkaos/webkaos"
 
-ARG WEBKAOS_VER=1.26.0
-ARG BROTLI_VER=0.1.6
+ARG WEBKAOS_VER=1.26.1
 ARG REPOSITORY=kaos-release
 
 ARG UID=1001
@@ -23,7 +22,7 @@ ARG GID=1001
 
 # hadolint ignore=DL3031,DL3041
 RUN rpm -ivh https://pkgs.kaos.st/kaos-repo-latest.el8.noarch.rpm && \
-    microdnf -y install --enablerepo=${REPOSITORY} webkaos-${WEBKAOS_VER} webkaos-module-brotli-${BROTLI_VER} gettext && \
+    microdnf -y install --enablerepo=${REPOSITORY} webkaos-${WEBKAOS_VER} gettext && \
     microdnf clean all && \
     rm -rf /var/cache/dnf /var/log/dnf.* && \
     rm -rf /tmp/* && \

--- a/.docker/ol8.docker
+++ b/.docker/ol8.docker
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.title="WEBKAOS" \
       org.opencontainers.image.url="https://kaos.sh/webkaos" \
       org.opencontainers.image.source="https://github.com/essentialkaos/webkaos"
 
-ARG WEBKAOS_VER=1.26.1
+ARG WEBKAOS_VER=1.26.2
 ARG REPOSITORY=kaos-release
 
 # hadolint ignore=DL3031,DL3041

--- a/.docker/ol8.docker
+++ b/.docker/ol8.docker
@@ -14,13 +14,12 @@ LABEL org.opencontainers.image.title="WEBKAOS" \
       org.opencontainers.image.url="https://kaos.sh/webkaos" \
       org.opencontainers.image.source="https://github.com/essentialkaos/webkaos"
 
-ARG WEBKAOS_VER=1.26.0
-ARG BROTLI_VER=0.1.6
+ARG WEBKAOS_VER=1.26.1
 ARG REPOSITORY=kaos-release
 
 # hadolint ignore=DL3031,DL3041
 RUN rpm -ivh https://pkgs.kaos.st/kaos-repo-latest.el8.noarch.rpm && \
-    microdnf -y install --enablerepo=${REPOSITORY} webkaos-${WEBKAOS_VER} webkaos-module-brotli-${BROTLI_VER} gettext && \
+    microdnf -y install --enablerepo=${REPOSITORY} webkaos-${WEBKAOS_VER} gettext && \
     microdnf clean all && \
     rm -rf /var/cache/dnf /var/log/dnf.* && \
     rm -rf /tmp/* && \

--- a/.docker/ol9-unprivileged.docker
+++ b/.docker/ol9-unprivileged.docker
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.title="WEBKAOS (Unprivileged)" \
       org.opencontainers.image.url="https://kaos.sh/webkaos" \
       org.opencontainers.image.source="https://github.com/essentialkaos/webkaos"
 
-ARG WEBKAOS_VER=1.26.1
+ARG WEBKAOS_VER=1.26.2
 ARG REPOSITORY=kaos-release
 
 ARG UID=1001

--- a/.docker/ol9-unprivileged.docker
+++ b/.docker/ol9-unprivileged.docker
@@ -14,8 +14,7 @@ LABEL org.opencontainers.image.title="WEBKAOS (Unprivileged)" \
       org.opencontainers.image.url="https://kaos.sh/webkaos" \
       org.opencontainers.image.source="https://github.com/essentialkaos/webkaos"
 
-ARG WEBKAOS_VER=1.26.0
-ARG BROTLI_VER=0.1.6
+ARG WEBKAOS_VER=1.26.1
 ARG REPOSITORY=kaos-release
 
 ARG UID=1001
@@ -23,7 +22,7 @@ ARG GID=1001
 
 # hadolint ignore=DL3031,DL3041
 RUN rpm -ivh https://pkgs.kaos.st/kaos-repo-latest.el9.noarch.rpm && \
-    microdnf -y install --enablerepo=${REPOSITORY} webkaos-${WEBKAOS_VER} webkaos-module-brotli-${BROTLI_VER} gettext && \
+    microdnf -y install --enablerepo=${REPOSITORY} webkaos-${WEBKAOS_VER} gettext && \
     microdnf clean all && \
     rm -rf /var/cache/dnf /var/log/dnf.* && \
     rm -rf /tmp/* && \

--- a/.docker/ol9.docker
+++ b/.docker/ol9.docker
@@ -14,13 +14,12 @@ LABEL org.opencontainers.image.title="WEBKAOS" \
       org.opencontainers.image.url="https://kaos.sh/webkaos" \
       org.opencontainers.image.source="https://github.com/essentialkaos/webkaos"
 
-ARG WEBKAOS_VER=1.26.0
-ARG BROTLI_VER=0.1.6
+ARG WEBKAOS_VER=1.26.1
 ARG REPOSITORY=kaos-release
 
 # hadolint ignore=DL3031,DL3041
 RUN rpm -ivh https://pkgs.kaos.st/kaos-repo-latest.el9.noarch.rpm && \
-    microdnf -y install --enablerepo=${REPOSITORY} webkaos-${WEBKAOS_VER} webkaos-module-brotli-${BROTLI_VER} gettext && \
+    microdnf -y install --enablerepo=${REPOSITORY} webkaos-${WEBKAOS_VER} gettext && \
     microdnf clean all && \
     rm -rf /var/cache/dnf /var/log/dnf.* && \
     rm -rf /tmp/* && \

--- a/.docker/ol9.docker
+++ b/.docker/ol9.docker
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.title="WEBKAOS" \
       org.opencontainers.image.url="https://kaos.sh/webkaos" \
       org.opencontainers.image.source="https://github.com/essentialkaos/webkaos"
 
-ARG WEBKAOS_VER=1.26.1
+ARG WEBKAOS_VER=1.26.2
 ARG REPOSITORY=kaos-release
 
 # hadolint ignore=DL3031,DL3041

--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@
 ```bash
 sudo dnf install -y https://pkgs.kaos.st/kaos-repo-latest.el$(grep 'CPE_NAME' /etc/os-release | tr -d '"' | cut -d':' -f5).noarch.rpm
 sudo dnf install webkaos
-# Install optional modules
-sudo dnf install
 ```
 
 #### Using Docker

--- a/SOURCES/webkaos.patch
+++ b/SOURCES/webkaos.patch
@@ -1,6 +1,6 @@
-diff --color -urN nginx-1.26.1-orig/auto/lib/openssl/make nginx-1.26.1/auto/lib/openssl/make
---- nginx-1.26.1-orig/auto/lib/openssl/make	2024-05-28 16:28:07.000000000 +0300
-+++ nginx-1.26.1/auto/lib/openssl/make	2024-06-14 15:44:38.628467319 +0300
+diff --color -urN nginx-1.26.2-orig/auto/lib/openssl/make nginx-1.26.2/auto/lib/openssl/make
+--- nginx-1.26.2-orig/auto/lib/openssl/make	2024-08-12 17:28:31.000000000 +0300
++++ nginx-1.26.2/auto/lib/openssl/make	2024-08-15 15:03:06.835407722 +0300
 @@ -58,18 +58,18 @@
              /*) ngx_prefix="$OPENSSL/.openssl" ;;
              *)  ngx_prefix="$PWD/$OPENSSL/.openssl" ;;
@@ -24,9 +24,9 @@ diff --color -urN nginx-1.26.1-orig/auto/lib/openssl/make nginx-1.26.1/auto/lib/
      ;;
  
  esac
-diff --color -urN nginx-1.26.1-orig/src/core/nginx.c nginx-1.26.1/src/core/nginx.c
---- nginx-1.26.1-orig/src/core/nginx.c	2024-05-28 16:28:07.000000000 +0300
-+++ nginx-1.26.1/src/core/nginx.c	2024-06-14 15:44:38.636467338 +0300
+diff --color -urN nginx-1.26.2-orig/src/core/nginx.c nginx-1.26.2/src/core/nginx.c
+--- nginx-1.26.2-orig/src/core/nginx.c	2024-08-12 17:28:31.000000000 +0300
++++ nginx-1.26.2/src/core/nginx.c	2024-08-15 15:03:06.842407844 +0300
 @@ -391,12 +391,12 @@
  static void
  ngx_show_version_info(void)
@@ -43,13 +43,13 @@ diff --color -urN nginx-1.26.1-orig/src/core/nginx.c nginx-1.26.1/src/core/nginx
                            NGX_LINEFEED NGX_LINEFEED
              "Options:" NGX_LINEFEED
              "  -?,-h         : this help" NGX_LINEFEED
-diff --color -urN nginx-1.26.1-orig/src/core/nginx.h nginx-1.26.1/src/core/nginx.h
---- nginx-1.26.1-orig/src/core/nginx.h	2024-05-28 16:28:07.000000000 +0300
-+++ nginx-1.26.1/src/core/nginx.h	2024-06-14 15:45:05.000000000 +0300
+diff --color -urN nginx-1.26.2-orig/src/core/nginx.h nginx-1.26.2/src/core/nginx.h
+--- nginx-1.26.2-orig/src/core/nginx.h	2024-08-12 17:28:31.000000000 +0300
++++ nginx-1.26.2/src/core/nginx.h	2024-08-15 15:03:32.000000000 +0300
 @@ -11,7 +11,7 @@
  
- #define nginx_version      1026001
- #define NGINX_VERSION      "1.26.1"
+ #define nginx_version      1026002
+ #define NGINX_VERSION      "1.26.2"
 -#define NGINX_VER          "nginx/" NGINX_VERSION
 +#define NGINX_VER          "webkaos/" NGINX_VERSION
  
@@ -64,9 +64,9 @@ diff --color -urN nginx-1.26.1-orig/src/core/nginx.h nginx-1.26.1/src/core/nginx
  #define NGX_OLDPID_EXT     ".oldbin"
  
  
-diff --color -urN nginx-1.26.1-orig/src/core/ngx_log.c nginx-1.26.1/src/core/ngx_log.c
---- nginx-1.26.1-orig/src/core/ngx_log.c	2024-05-28 16:28:07.000000000 +0300
-+++ nginx-1.26.1/src/core/ngx_log.c	2024-06-14 15:44:38.650467372 +0300
+diff --color -urN nginx-1.26.2-orig/src/core/ngx_log.c nginx-1.26.2/src/core/ngx_log.c
+--- nginx-1.26.2-orig/src/core/ngx_log.c	2024-08-12 17:28:31.000000000 +0300
++++ nginx-1.26.2/src/core/ngx_log.c	2024-08-15 15:03:06.854408052 +0300
 @@ -202,9 +202,9 @@
          return;
      }
@@ -97,9 +97,9 @@ diff --color -urN nginx-1.26.1-orig/src/core/ngx_log.c nginx-1.26.1/src/core/ngx
          return NGX_CONF_ERROR;
  #endif
  
-diff --color -urN nginx-1.26.1-orig/src/http/modules/ngx_http_autoindex_module.c nginx-1.26.1/src/http/modules/ngx_http_autoindex_module.c
---- nginx-1.26.1-orig/src/http/modules/ngx_http_autoindex_module.c	2024-05-28 16:28:07.000000000 +0300
-+++ nginx-1.26.1/src/http/modules/ngx_http_autoindex_module.c	2024-06-14 15:44:38.658467391 +0300
+diff --color -urN nginx-1.26.2-orig/src/http/modules/ngx_http_autoindex_module.c nginx-1.26.2/src/http/modules/ngx_http_autoindex_module.c
+--- nginx-1.26.2-orig/src/http/modules/ngx_http_autoindex_module.c	2024-08-12 17:28:31.000000000 +0300
++++ nginx-1.26.2/src/http/modules/ngx_http_autoindex_module.c	2024-08-15 15:03:06.863408209 +0300
 @@ -449,9 +449,11 @@
      ;
  
@@ -175,9 +175,9 @@ diff --color -urN nginx-1.26.1-orig/src/http/modules/ngx_http_autoindex_module.c
                                tm.ngx_tm_mday,
                                months[tm.ngx_tm_mon - 1],
                                tm.ngx_tm_year,
-diff --color -urN nginx-1.26.1-orig/src/http/ngx_http_header_filter_module.c nginx-1.26.1/src/http/ngx_http_header_filter_module.c
---- nginx-1.26.1-orig/src/http/ngx_http_header_filter_module.c	2024-05-28 16:28:07.000000000 +0300
-+++ nginx-1.26.1/src/http/ngx_http_header_filter_module.c	2024-06-14 15:44:38.666467410 +0300
+diff --color -urN nginx-1.26.2-orig/src/http/ngx_http_header_filter_module.c nginx-1.26.2/src/http/ngx_http_header_filter_module.c
+--- nginx-1.26.2-orig/src/http/ngx_http_header_filter_module.c	2024-08-12 17:28:31.000000000 +0300
++++ nginx-1.26.2/src/http/ngx_http_header_filter_module.c	2024-08-15 15:03:06.869408314 +0300
 @@ -46,7 +46,7 @@
  };
  
@@ -228,9 +228,9 @@ diff --color -urN nginx-1.26.1-orig/src/http/ngx_http_header_filter_module.c ngi
  #define NGX_HTTP_OFF_5XX   (NGX_HTTP_LAST_4XX - 400 + NGX_HTTP_OFF_4XX)
  
      ngx_string("500 Internal Server Error"),
-diff --color -urN nginx-1.26.1-orig/src/http/ngx_http_special_response.c nginx-1.26.1/src/http/ngx_http_special_response.c
---- nginx-1.26.1-orig/src/http/ngx_http_special_response.c	2024-05-28 16:28:07.000000000 +0300
-+++ nginx-1.26.1/src/http/ngx_http_special_response.c	2024-06-14 15:44:38.674467429 +0300
+diff --color -urN nginx-1.26.2-orig/src/http/ngx_http_special_response.c nginx-1.26.2/src/http/ngx_http_special_response.c
+--- nginx-1.26.2-orig/src/http/ngx_http_special_response.c	2024-08-12 17:28:31.000000000 +0300
++++ nginx-1.26.2/src/http/ngx_http_special_response.c	2024-08-15 15:03:06.875408418 +0300
 @@ -19,21 +19,21 @@
  
  
@@ -703,9 +703,9 @@ diff --color -urN nginx-1.26.1-orig/src/http/ngx_http_special_response.c nginx-1
  #define NGX_HTTP_OFF_5XX   (NGX_HTTP_LAST_4XX - 400 + NGX_HTTP_OFF_4XX)
  
      ngx_string(ngx_http_error_494_page), /* 494, request header too large */
-diff --color -urN nginx-1.26.1-orig/src/http/v2/ngx_http_v2_filter_module.c nginx-1.26.1/src/http/v2/ngx_http_v2_filter_module.c
---- nginx-1.26.1-orig/src/http/v2/ngx_http_v2_filter_module.c	2024-05-28 16:28:07.000000000 +0300
-+++ nginx-1.26.1/src/http/v2/ngx_http_v2_filter_module.c	2024-06-14 15:44:38.682467448 +0300
+diff --color -urN nginx-1.26.2-orig/src/http/v2/ngx_http_v2_filter_module.c nginx-1.26.2/src/http/v2/ngx_http_v2_filter_module.c
+--- nginx-1.26.2-orig/src/http/v2/ngx_http_v2_filter_module.c	2024-08-12 17:28:31.000000000 +0300
++++ nginx-1.26.2/src/http/v2/ngx_http_v2_filter_module.c	2024-08-15 15:03:06.882408540 +0300
 @@ -115,7 +115,7 @@
      ngx_http_core_srv_conf_t  *cscf;
      u_char                     addr[NGX_SOCKADDR_STRLEN];
@@ -724,9 +724,9 @@ diff --color -urN nginx-1.26.1-orig/src/http/v2/ngx_http_v2_filter_module.c ngin
          }
  
          *pos++ = ngx_http_v2_inc_indexed(NGX_HTTP_V2_SERVER_INDEX);
-diff --color -urN nginx-1.26.1-orig/src/os/unix/ngx_setproctitle.c nginx-1.26.1/src/os/unix/ngx_setproctitle.c
---- nginx-1.26.1-orig/src/os/unix/ngx_setproctitle.c	2024-05-28 16:28:07.000000000 +0300
-+++ nginx-1.26.1/src/os/unix/ngx_setproctitle.c	2024-06-14 15:44:38.690467468 +0300
+diff --color -urN nginx-1.26.2-orig/src/os/unix/ngx_setproctitle.c nginx-1.26.2/src/os/unix/ngx_setproctitle.c
+--- nginx-1.26.2-orig/src/os/unix/ngx_setproctitle.c	2024-08-12 17:28:31.000000000 +0300
++++ nginx-1.26.2/src/os/unix/ngx_setproctitle.c	2024-08-15 15:03:06.889408662 +0300
 @@ -89,7 +89,7 @@
  
      ngx_os_argv[1] = NULL;

--- a/webkaos.spec
+++ b/webkaos.spec
@@ -23,11 +23,11 @@
 %define service_name   %{name}
 %define service_home   %{_cachedir}/%{service_name}
 
-%define nginx_version       1.26.1
+%define nginx_version       1.26.2
 %define lua_module_ver      0.10.26
-%define lua_resty_core_ver  0.1.28
-%define lua_resty_lru_ver   0.13
-%define mh_module_ver       0.34
+%define lua_resty_core_ver  0.1.29
+%define lua_resty_lru_ver   0.14
+%define mh_module_ver       0.37
 %define pcre_ver            8.45
 %define zlib_ver            1.3.1
 %define luajit_ver          2.1-20240314
@@ -565,6 +565,12 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Thu Aug 15 2024 Anton Novojilov <andy@essentialkaos.com> - 1.26.2-0
+- Nginx updated to 1.26.2 with fixes for CVE-2024-7347
+- More Headers module updated to 0.37
+- lua-resty-lru updated to 0.14
+- lua-resty-core updated to 0.1.29
+
 * Fri Jun 14 2024 Anton Novojilov <andy@essentialkaos.com> - 1.26.1-0
 - Nginx updated to 1.26.1
 

--- a/webkaos.spec
+++ b/webkaos.spec
@@ -24,7 +24,7 @@
 %define service_home   %{_cachedir}/%{service_name}
 
 %define nginx_version       1.26.2
-%define lua_module_ver      0.10.26
+%define lua_module_ver      0.10.27
 %define lua_resty_core_ver  0.1.29
 %define lua_resty_lru_ver   0.14
 %define mh_module_ver       0.37
@@ -568,6 +568,7 @@ rm -rf %{buildroot}
 * Thu Aug 15 2024 Anton Novojilov <andy@essentialkaos.com> - 1.26.2-0
 - Nginx updated to 1.26.2 with fixes for CVE-2024-7347
 - More Headers module updated to 0.37
+- lua-nginx-module updated to 0.10.27
 - lua-resty-lru updated to 0.14
 - lua-resty-core updated to 0.1.29
 


### PR DESCRIPTION
#### Improvements
- Nginx updated to `1.26.2` with fixes for CVE-2024-7347
- More Headers module updated to `0.37`
- lua-nginx-module updated to `0.10.27`
- lua-resty-lru updated to `0.14`
- lua-resty-core updated to `0.1.29`
