### PR TITLE
Version 1.28.0

### DIFF
--- a/.docker/ol8-unprivileged.docker
+++ b/.docker/ol8-unprivileged.docker
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.title="WEBKAOS (Unprivileged)" \
       org.opencontainers.image.url="https://kaos.sh/webkaos" \
       org.opencontainers.image.source="https://github.com/essentialkaos/webkaos"
 
-ARG WEBKAOS_VER=1.26.3
+ARG WEBKAOS_VER=1.28.0
 ARG REPOSITORY=kaos-release
 
 ARG UID=1001

--- a/.docker/ol8.docker
+++ b/.docker/ol8.docker
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.title="WEBKAOS" \
       org.opencontainers.image.url="https://kaos.sh/webkaos" \
       org.opencontainers.image.source="https://github.com/essentialkaos/webkaos"
 
-ARG WEBKAOS_VER=1.26.3
+ARG WEBKAOS_VER=1.28.0
 ARG REPOSITORY=kaos-release
 
 # hadolint ignore=DL3031,DL3041

--- a/.docker/ol9-unprivileged.docker
+++ b/.docker/ol9-unprivileged.docker
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.title="WEBKAOS (Unprivileged)" \
       org.opencontainers.image.url="https://kaos.sh/webkaos" \
       org.opencontainers.image.source="https://github.com/essentialkaos/webkaos"
 
-ARG WEBKAOS_VER=1.26.3
+ARG WEBKAOS_VER=1.28.0
 ARG REPOSITORY=kaos-release
 
 ARG UID=1001

--- a/.docker/ol9.docker
+++ b/.docker/ol9.docker
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.title="WEBKAOS" \
       org.opencontainers.image.url="https://kaos.sh/webkaos" \
       org.opencontainers.image.source="https://github.com/essentialkaos/webkaos"
 
-ARG WEBKAOS_VER=1.26.3
+ARG WEBKAOS_VER=1.28.0
 ARG REPOSITORY=kaos-release
 
 # hadolint ignore=DL3031,DL3041

--- a/SOURCES/webkaos-dynamic-tls-records.patch
+++ b/SOURCES/webkaos-dynamic-tls-records.patch
@@ -1,7 +1,7 @@
-diff --color -urN nginx-1.26.0-orig/src/event/ngx_event_openssl.c nginx-1.26.0-dynamic-tls/src/event/ngx_event_openssl.c
---- nginx-1.26.0-orig/src/event/ngx_event_openssl.c	2024-04-23 17:04:32.000000000 +0300
-+++ nginx-1.26.0-dynamic-tls/src/event/ngx_event_openssl.c	2024-05-03 17:39:25.000000000 +0300
-@@ -1712,6 +1712,7 @@
+diff --color -urN nginx-1.28.0-orig/src/event/ngx_event_openssl.c nginx-1.28.0/src/event/ngx_event_openssl.c
+--- nginx-1.28.0-orig/src/event/ngx_event_openssl.c	2025-04-23 14:48:54.000000000 +0300
++++ nginx-1.28.0/src/event/ngx_event_openssl.c	2025-05-19 00:40:10.000000000 +0300
+@@ -1620,6 +1620,7 @@
  
      sc->buffer = ((flags & NGX_SSL_BUFFER) != 0);
      sc->buffer_size = ssl->buffer_size;
@@ -9,10 +9,10 @@ diff --color -urN nginx-1.26.0-orig/src/event/ngx_event_openssl.c nginx-1.26.0-d
  
      sc->session_ctx = ssl->ctx;
  
-@@ -2682,6 +2683,40 @@
-     flush = (in == NULL) ? 1 : buf->flush;
+@@ -2591,6 +2592,41 @@
  
      for ( ;; ) {
+ 
 +        /* Dynamic record resizing:
 +           We want the initial records to fit into one TCP segment
 +           so we don't get TCP HoL blocking due to TCP Slow Start.
@@ -47,10 +47,11 @@ diff --color -urN nginx-1.26.0-orig/src/event/ngx_event_openssl.c nginx-1.26.0-d
 +                }
 +            }
 +        }
- 
++
          while (in && buf->last < buf->end && send < limit) {
              if (in->buf->last_buf || in->buf->flush) {
-@@ -2822,6 +2857,9 @@
+                 flush = 1;
+@@ -2730,6 +2766,9 @@
  
      if (n > 0) {
  
@@ -60,7 +61,7 @@ diff --color -urN nginx-1.26.0-orig/src/event/ngx_event_openssl.c nginx-1.26.0-d
          if (c->ssl->saved_read_handler) {
  
              c->read->handler = c->ssl->saved_read_handler;
-@@ -2933,6 +2971,9 @@
+@@ -2841,6 +2880,9 @@
  
      if (n > 0) {
  
@@ -70,7 +71,7 @@ diff --color -urN nginx-1.26.0-orig/src/event/ngx_event_openssl.c nginx-1.26.0-d
          if (c->ssl->saved_read_handler) {
  
              c->read->handler = c->ssl->saved_read_handler;
-@@ -3064,6 +3105,9 @@
+@@ -2972,6 +3014,9 @@
  
      if (n > 0) {
  
@@ -80,9 +81,9 @@ diff --color -urN nginx-1.26.0-orig/src/event/ngx_event_openssl.c nginx-1.26.0-d
          if (c->ssl->saved_read_handler) {
  
              c->read->handler = c->ssl->saved_read_handler;
-diff --color -urN nginx-1.26.0-orig/src/event/ngx_event_openssl.h nginx-1.26.0-dynamic-tls/src/event/ngx_event_openssl.h
---- nginx-1.26.0-orig/src/event/ngx_event_openssl.h	2024-04-23 17:04:32.000000000 +0300
-+++ nginx-1.26.0-dynamic-tls/src/event/ngx_event_openssl.h	2024-05-03 17:40:54.000000000 +0300
+diff --color -urN nginx-1.28.0-orig/src/event/ngx_event_openssl.h nginx-1.28.0/src/event/ngx_event_openssl.h
+--- nginx-1.28.0-orig/src/event/ngx_event_openssl.h	2025-04-23 14:48:54.000000000 +0300
++++ nginx-1.28.0/src/event/ngx_event_openssl.h	2025-05-19 00:43:06.000000000 +0300
 @@ -68,6 +68,13 @@
  #define ngx_ssl_conn_t          SSL
  
@@ -102,10 +103,10 @@ diff --color -urN nginx-1.26.0-orig/src/event/ngx_event_openssl.h nginx-1.26.0-d
      ngx_log_t                  *log;
      size_t                      buffer_size;
 +    ngx_ssl_dyn_rec_t           dyn_rec;
- };
  
+     ngx_array_t                 certs;
  
-@@ -113,6 +121,10 @@
+@@ -118,6 +126,10 @@
  
      u_char                      early_buf;
  
@@ -116,19 +117,19 @@ diff --color -urN nginx-1.26.0-orig/src/event/ngx_event_openssl.h nginx-1.26.0-d
      unsigned                    handshaked:1;
      unsigned                    handshake_rejected:1;
      unsigned                    renegotiation:1;
-@@ -137,7 +149,7 @@
+@@ -142,7 +154,7 @@
  #define NGX_SSL_DFLT_BUILTIN_SCACHE  -5
  
  
--#define NGX_SSL_MAX_SESSION_SIZE  4096
+-#define NGX_SSL_MAX_SESSION_SIZE  8192
 +#define NGX_SSL_MAX_SESSION_SIZE  16384
  
  typedef struct ngx_ssl_sess_id_s  ngx_ssl_sess_id_t;
  
-diff --color -urN nginx-1.26.0-orig/src/http/modules/ngx_http_ssl_module.c nginx-1.26.0-dynamic-tls/src/http/modules/ngx_http_ssl_module.c
---- nginx-1.26.0-orig/src/http/modules/ngx_http_ssl_module.c	2024-04-23 17:04:32.000000000 +0300
-+++ nginx-1.26.0-dynamic-tls/src/http/modules/ngx_http_ssl_module.c	2024-05-03 17:43:48.000000000 +0300
-@@ -290,6 +290,41 @@
+diff --color -urN nginx-1.28.0-orig/src/http/modules/ngx_http_ssl_module.c nginx-1.28.0/src/http/modules/ngx_http_ssl_module.c
+--- nginx-1.28.0-orig/src/http/modules/ngx_http_ssl_module.c	2025-04-23 14:48:54.000000000 +0300
++++ nginx-1.28.0/src/http/modules/ngx_http_ssl_module.c	2025-05-19 00:47:38.000000000 +0300
+@@ -299,6 +299,41 @@
        offsetof(ngx_http_ssl_srv_conf_t, reject_handshake),
        NULL },
  
@@ -170,7 +171,7 @@ diff --color -urN nginx-1.26.0-orig/src/http/modules/ngx_http_ssl_module.c nginx
        ngx_null_command
  };
  
-@@ -629,6 +664,11 @@
+@@ -639,6 +674,11 @@
      sscf->ocsp_cache_zone = NGX_CONF_UNSET_PTR;
      sscf->stapling = NGX_CONF_UNSET;
      sscf->stapling_verify = NGX_CONF_UNSET;
@@ -182,7 +183,7 @@ diff --color -urN nginx-1.26.0-orig/src/http/modules/ngx_http_ssl_module.c nginx
  
      return sscf;
  }
-@@ -694,6 +734,20 @@
+@@ -705,6 +745,20 @@
      ngx_conf_merge_str_value(conf->stapling_responder,
                           prev->stapling_responder, "");
  
@@ -203,7 +204,7 @@ diff --color -urN nginx-1.26.0-orig/src/http/modules/ngx_http_ssl_module.c nginx
      conf->ssl.log = cf->log;
  
      if (conf->certificates) {
-@@ -890,6 +944,28 @@
+@@ -905,6 +959,28 @@
          return NGX_CONF_ERROR;
      }
  
@@ -232,10 +233,10 @@ diff --color -urN nginx-1.26.0-orig/src/http/modules/ngx_http_ssl_module.c nginx
      return NGX_CONF_OK;
  }
  
-diff --color -urN nginx-1.26.0-orig/src/http/modules/ngx_http_ssl_module.h nginx-1.26.0-dynamic-tls/src/http/modules/ngx_http_ssl_module.h
---- nginx-1.26.0-orig/src/http/modules/ngx_http_ssl_module.h	2024-04-23 17:04:32.000000000 +0300
-+++ nginx-1.26.0-dynamic-tls/src/http/modules/ngx_http_ssl_module.h	2024-05-03 17:44:38.000000000 +0300
-@@ -62,6 +62,12 @@
+diff --color -urN nginx-1.28.0-orig/src/http/modules/ngx_http_ssl_module.h nginx-1.28.0/src/http/modules/ngx_http_ssl_module.h
+--- nginx-1.28.0-orig/src/http/modules/ngx_http_ssl_module.h	2025-04-23 14:48:54.000000000 +0300
++++ nginx-1.28.0/src/http/modules/ngx_http_ssl_module.h	2025-05-19 00:48:04.000000000 +0300
+@@ -64,6 +64,12 @@
      ngx_flag_t                      stapling_verify;
      ngx_str_t                       stapling_file;
      ngx_str_t                       stapling_responder;

--- a/SOURCES/webkaos.conf
+++ b/SOURCES/webkaos.conf
@@ -23,7 +23,7 @@ include modules.conf;
 ################################################################################
 
 error_log  /var/log/webkaos/error.log warn;
-pid        /var/run/webkaos.pid;
+pid        /run/webkaos.pid;
 
 ################################################################################
 

--- a/SOURCES/webkaos.patch
+++ b/SOURCES/webkaos.patch
@@ -1,6 +1,6 @@
-diff --color -urN nginx-1.26.3-orig/auto/lib/openssl/make nginx-1.26.3/auto/lib/openssl/make
---- nginx-1.26.3-orig/auto/lib/openssl/make	2025-02-05 14:07:30.000000000 +0300
-+++ nginx-1.26.3/auto/lib/openssl/make	2025-04-10 17:04:22.795141017 +0300
+diff --color -urN nginx-1.28.0-orig/auto/lib/openssl/make nginx-1.28.0/auto/lib/openssl/make
+--- nginx-1.28.0-orig/auto/lib/openssl/make	2025-04-23 14:48:54.000000000 +0300
++++ nginx-1.28.0/auto/lib/openssl/make	2025-05-19 00:21:35.801135997 +0300
 @@ -58,18 +58,18 @@
              /*) ngx_prefix="$OPENSSL/.openssl" ;;
              *)  ngx_prefix="$PWD/$OPENSSL/.openssl" ;;
@@ -24,9 +24,9 @@ diff --color -urN nginx-1.26.3-orig/auto/lib/openssl/make nginx-1.26.3/auto/lib/
      ;;
  
  esac
-diff --color -urN nginx-1.26.3-orig/src/core/nginx.c nginx-1.26.3/src/core/nginx.c
---- nginx-1.26.3-orig/src/core/nginx.c	2025-02-05 14:07:30.000000000 +0300
-+++ nginx-1.26.3/src/core/nginx.c	2025-04-10 17:04:22.807141369 +0300
+diff --color -urN nginx-1.28.0-orig/src/core/nginx.c nginx-1.28.0/src/core/nginx.c
+--- nginx-1.28.0-orig/src/core/nginx.c	2025-04-23 14:48:54.000000000 +0300
++++ nginx-1.28.0/src/core/nginx.c	2025-05-19 00:21:35.810136260 +0300
 @@ -391,12 +391,12 @@
  static void
  ngx_show_version_info(void)
@@ -43,13 +43,13 @@ diff --color -urN nginx-1.26.3-orig/src/core/nginx.c nginx-1.26.3/src/core/nginx
                            NGX_LINEFEED NGX_LINEFEED
              "Options:" NGX_LINEFEED
              "  -?,-h         : this help" NGX_LINEFEED
-diff --color -urN nginx-1.26.3-orig/src/core/nginx.h nginx-1.26.3/src/core/nginx.h
---- nginx-1.26.3-orig/src/core/nginx.h	2025-02-05 14:07:30.000000000 +0300
-+++ nginx-1.26.3/src/core/nginx.h	2025-04-10 17:05:12.000000000 +0300
+diff --color -urN nginx-1.28.0-orig/src/core/nginx.h nginx-1.28.0/src/core/nginx.h
+--- nginx-1.28.0-orig/src/core/nginx.h	2025-04-23 14:48:54.000000000 +0300
++++ nginx-1.28.0/src/core/nginx.h	2025-05-19 00:28:41.000000000 +0300
 @@ -11,7 +11,7 @@
  
- #define nginx_version      1026003
- #define NGINX_VERSION      "1.26.3"
+ #define nginx_version      1028000
+ #define NGINX_VERSION      "1.28.0"
 -#define NGINX_VER          "nginx/" NGINX_VERSION
 +#define NGINX_VER          "webkaos/" NGINX_VERSION
  
@@ -64,9 +64,9 @@ diff --color -urN nginx-1.26.3-orig/src/core/nginx.h nginx-1.26.3/src/core/nginx
  #define NGX_OLDPID_EXT     ".oldbin"
  
  
-diff --color -urN nginx-1.26.3-orig/src/core/ngx_log.c nginx-1.26.3/src/core/ngx_log.c
---- nginx-1.26.3-orig/src/core/ngx_log.c	2025-02-05 14:07:30.000000000 +0300
-+++ nginx-1.26.3/src/core/ngx_log.c	2025-04-10 17:04:22.819141721 +0300
+diff --color -urN nginx-1.28.0-orig/src/core/ngx_log.c nginx-1.28.0/src/core/ngx_log.c
+--- nginx-1.28.0-orig/src/core/ngx_log.c	2025-04-23 14:48:54.000000000 +0300
++++ nginx-1.28.0/src/core/ngx_log.c	2025-05-19 00:21:35.821136581 +0300
 @@ -202,9 +202,9 @@
          return;
      }
@@ -97,9 +97,9 @@ diff --color -urN nginx-1.26.3-orig/src/core/ngx_log.c nginx-1.26.3/src/core/ngx
          return NGX_CONF_ERROR;
  #endif
  
-diff --color -urN nginx-1.26.3-orig/src/http/modules/ngx_http_autoindex_module.c nginx-1.26.3/src/http/modules/ngx_http_autoindex_module.c
---- nginx-1.26.3-orig/src/http/modules/ngx_http_autoindex_module.c	2025-02-05 14:07:30.000000000 +0300
-+++ nginx-1.26.3/src/http/modules/ngx_http_autoindex_module.c	2025-04-10 17:04:22.835142190 +0300
+diff --color -urN nginx-1.28.0-orig/src/http/modules/ngx_http_autoindex_module.c nginx-1.28.0/src/http/modules/ngx_http_autoindex_module.c
+--- nginx-1.28.0-orig/src/http/modules/ngx_http_autoindex_module.c	2025-04-23 14:48:54.000000000 +0300
++++ nginx-1.28.0/src/http/modules/ngx_http_autoindex_module.c	2025-05-19 00:21:35.830136844 +0300
 @@ -449,9 +449,11 @@
      ;
  
@@ -175,9 +175,9 @@ diff --color -urN nginx-1.26.3-orig/src/http/modules/ngx_http_autoindex_module.c
                                tm.ngx_tm_mday,
                                months[tm.ngx_tm_mon - 1],
                                tm.ngx_tm_year,
-diff --color -urN nginx-1.26.3-orig/src/http/ngx_http_header_filter_module.c nginx-1.26.3/src/http/ngx_http_header_filter_module.c
---- nginx-1.26.3-orig/src/http/ngx_http_header_filter_module.c	2025-02-05 14:07:30.000000000 +0300
-+++ nginx-1.26.3/src/http/ngx_http_header_filter_module.c	2025-04-10 17:04:22.843142425 +0300
+diff --color -urN nginx-1.28.0-orig/src/http/ngx_http_header_filter_module.c nginx-1.28.0/src/http/ngx_http_header_filter_module.c
+--- nginx-1.28.0-orig/src/http/ngx_http_header_filter_module.c	2025-04-23 14:48:54.000000000 +0300
++++ nginx-1.28.0/src/http/ngx_http_header_filter_module.c	2025-05-19 00:21:35.838137077 +0300
 @@ -46,7 +46,7 @@
  };
  
@@ -228,9 +228,9 @@ diff --color -urN nginx-1.26.3-orig/src/http/ngx_http_header_filter_module.c ngi
  #define NGX_HTTP_OFF_5XX   (NGX_HTTP_LAST_4XX - 400 + NGX_HTTP_OFF_4XX)
  
      ngx_string("500 Internal Server Error"),
-diff --color -urN nginx-1.26.3-orig/src/http/ngx_http_special_response.c nginx-1.26.3/src/http/ngx_http_special_response.c
---- nginx-1.26.3-orig/src/http/ngx_http_special_response.c	2025-02-05 14:07:30.000000000 +0300
-+++ nginx-1.26.3/src/http/ngx_http_special_response.c	2025-04-10 17:04:22.849142600 +0300
+diff --color -urN nginx-1.28.0-orig/src/http/ngx_http_special_response.c nginx-1.28.0/src/http/ngx_http_special_response.c
+--- nginx-1.28.0-orig/src/http/ngx_http_special_response.c	2025-04-23 14:48:54.000000000 +0300
++++ nginx-1.28.0/src/http/ngx_http_special_response.c	2025-05-19 00:21:35.845137282 +0300
 @@ -19,21 +19,21 @@
  
  
@@ -703,19 +703,19 @@ diff --color -urN nginx-1.26.3-orig/src/http/ngx_http_special_response.c nginx-1
  #define NGX_HTTP_OFF_5XX   (NGX_HTTP_LAST_4XX - 400 + NGX_HTTP_OFF_4XX)
  
      ngx_string(ngx_http_error_494_page), /* 494, request header too large */
-diff --color -urN nginx-1.26.3-orig/src/http/v2/ngx_http_v2_filter_module.c nginx-1.26.3/src/http/v2/ngx_http_v2_filter_module.c
---- nginx-1.26.3-orig/src/http/v2/ngx_http_v2_filter_module.c	2025-02-05 14:07:30.000000000 +0300
-+++ nginx-1.26.3/src/http/v2/ngx_http_v2_filter_module.c	2025-04-10 17:04:22.858142864 +0300
+diff --color -urN nginx-1.28.0-orig/src/http/v2/ngx_http_v2_filter_module.c nginx-1.28.0/src/http/v2/ngx_http_v2_filter_module.c
+--- nginx-1.28.0-orig/src/http/v2/ngx_http_v2_filter_module.c	2025-04-23 14:48:54.000000000 +0300
++++ nginx-1.28.0/src/http/v2/ngx_http_v2_filter_module.c	2025-05-19 00:24:25.000000000 +0300
 @@ -115,7 +115,7 @@
      ngx_http_core_srv_conf_t  *cscf;
      u_char                     addr[NGX_SOCKADDR_STRLEN];
  
--    static const u_char nginx[5] = "\x84\xaa\x63\x55\xe7";
-+    static const u_char nginx[6] = "\x85\xf0\x58\xfa\x8c\xe8";
+-    static const u_char nginx[5] = { 0x84, 0xaa, 0x63, 0x55, 0xe7 };
++    static const u_char nginx[6] = { 0x85, 0xf0, 0x58, 0xfa, 0x8c, 0xe8 };
  #if (NGX_HTTP_GZIP)
-     static const u_char accept_encoding[12] =
-         "\x8b\x84\x84\x2d\x69\x5b\x05\x44\x3c\x86\xaa\x6f";
-@@ -435,7 +435,7 @@
+     static const u_char accept_encoding[12] = {
+         0x8b, 0x84, 0x84, 0x2d, 0x69, 0x5b, 0x05, 0x44, 0x3c, 0x86, 0xaa, 0x6f
+@@ -436,7 +436,7 @@
  
          } else {
              ngx_log_debug0(NGX_LOG_DEBUG_HTTP, fc->log, 0,
@@ -724,9 +724,32 @@ diff --color -urN nginx-1.26.3-orig/src/http/v2/ngx_http_v2_filter_module.c ngin
          }
  
          *pos++ = ngx_http_v2_inc_indexed(NGX_HTTP_V2_SERVER_INDEX);
-diff --color -urN nginx-1.26.3-orig/src/os/unix/ngx_setproctitle.c nginx-1.26.3/src/os/unix/ngx_setproctitle.c
---- nginx-1.26.3-orig/src/os/unix/ngx_setproctitle.c	2025-02-05 14:07:30.000000000 +0300
-+++ nginx-1.26.3/src/os/unix/ngx_setproctitle.c	2025-04-10 17:04:22.871143245 +0300
+diff --color -urN nginx-1.28.0-orig/src/http/v3/ngx_http_v3_filter_module.c nginx-1.28.0/src/http/v3/ngx_http_v3_filter_module.c
+--- nginx-1.28.0-orig/src/http/v3/ngx_http_v3_filter_module.c	2025-04-23 14:48:54.000000000 +0300
++++ nginx-1.28.0/src/http/v3/ngx_http_v3_filter_module.c	2025-05-19 00:25:13.000000000 +0300
+@@ -166,7 +166,7 @@
+             n = sizeof(NGINX_VER_BUILD) - 1;
+ 
+         } else {
+-            n = sizeof("nginx") - 1;
++            n = sizeof("webkaos") - 1;
+         }
+ 
+         len += ngx_http_v3_encode_field_lri(NULL, 0,
+@@ -349,8 +349,8 @@
+             n = sizeof(NGINX_VER_BUILD) - 1;
+ 
+         } else {
+-            p = (u_char *) "nginx";
+-            n = sizeof("nginx") - 1;
++            p = (u_char *) "webkaos";
++            n = sizeof("webkaos") - 1;
+         }
+ 
+         ngx_log_debug2(NGX_LOG_DEBUG_HTTP, c->log, 0,
+diff --color -urN nginx-1.28.0-orig/src/os/unix/ngx_setproctitle.c nginx-1.28.0/src/os/unix/ngx_setproctitle.c
+--- nginx-1.28.0-orig/src/os/unix/ngx_setproctitle.c	2025-04-23 14:48:54.000000000 +0300
++++ nginx-1.28.0/src/os/unix/ngx_setproctitle.c	2025-05-19 00:21:35.859137691 +0300
 @@ -89,7 +89,7 @@
  
      ngx_os_argv[1] = NULL;

--- a/webkaos.spec
+++ b/webkaos.spec
@@ -23,7 +23,7 @@
 %define service_name   %{name}
 %define service_home   %{_cachedir}/%{service_name}
 
-%define nginx_version       1.26.3
+%define nginx_version       1.28.0
 %define lua_module_ver      0.10.28
 %define lua_resty_core_ver  0.1.31
 %define lua_resty_lru_ver   0.15
@@ -35,7 +35,7 @@
 
 # 1. Open https://chromiumdash.appspot.com/releases?platform=Linux and note the latest stable version.
 # 2. Open https://chromium.googlesource.com/chromium/src/+/refs/tags/<version>/DEPS and note <boringssl_revision>.
-%define boring_commit  673e61fc215b178a90c0e67858bbf162c8158993
+%define boring_commit  a9993612faac4866bc33ca8ff37bfd0659af1c48
 
 ################################################################################
 
@@ -161,12 +161,12 @@ tar xzvf %{SOURCE60}
 mv CHANGES    NGINX-CHANGES
 mv CHANGES.ru NGINX-CHANGES.ru
 mv LICENSE    NGINX-LICENSE
-mv README     NGINX-README
+mv README.md  NGINX-README.md
 
-mv lua-nginx-module-%{lua_module_ver}/README.markdown ./LUA-MODULE-README.markdown
-mv lua-resty-core-%{lua_resty_core_ver}/README.markdown ./LUA-RESTY-CORE-README.markdown
-mv lua-resty-lrucache-%{lua_resty_lru_ver}/README.markdown ./LUA-RESTY-LRU-README.markdown
-mv headers-more-nginx-module-%{mh_module_ver}/README.markdown ./HEADERS-MORE-MODULE-README.markdown
+mv lua-nginx-module-%{lua_module_ver}/README.markdown ./LUA-MODULE-README.md
+mv lua-resty-core-%{lua_resty_core_ver}/README.markdown ./LUA-RESTY-CORE-README.md
+mv lua-resty-lrucache-%{lua_resty_lru_ver}/README.markdown ./LUA-RESTY-LRU-README.md
+mv headers-more-nginx-module-%{mh_module_ver}/README.markdown ./HEADERS-MORE-MODULE-README.md
 
 %if 0%{?rhel} <= 8
 # Use gcc and gcc-c++ from DevToolSet 11
@@ -490,8 +490,8 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root)
-%doc NGINX-CHANGES NGINX-CHANGES.ru NGINX-LICENSE NGINX-README
-%doc *-README.markdown
+%doc NGINX-CHANGES NGINX-CHANGES.ru NGINX-LICENSE
+%doc *-README.md
 
 %{_sbindir}/%{name}
 
@@ -557,6 +557,10 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Fri May 16 2025 Anton Novojilov <andy@essentialkaos.com> - 1.28.0-0
+- Nginx updated to 1.28.0
+- BoringSSL updated to the latest stable version for Chromium
+
 * Thu Apr 10 2025 Anton Novojilov <andy@essentialkaos.com> - 1.26.3-0
 - Nginx updated to 1.26.3 with fixes for CVE-2025-23419
 - More Headers module updated to 0.38


### PR DESCRIPTION
#### Improvements
- Nginx updated to `1.28.0`
- BoringSSL updated to the latest stable version for Chromium
