### PR TITLE
Version 1.28.3

### DIFF
--- a/.docker/ol10-unprivileged.docker
+++ b/.docker/ol10-unprivileged.docker
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.title="WEBKAOS (Unprivileged)" \
       org.opencontainers.image.url="https://kaos.sh/webkaos" \
       org.opencontainers.image.source="https://github.com/essentialkaos/webkaos"
 
-ARG WEBKAOS_VER=1.28.2
+ARG WEBKAOS_VER=1.28.3
 ARG REPOSITORY=kaos-release
 
 ARG UID=1001

--- a/.docker/ol10.docker
+++ b/.docker/ol10.docker
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.title="WEBKAOS" \
       org.opencontainers.image.url="https://kaos.sh/webkaos" \
       org.opencontainers.image.source="https://github.com/essentialkaos/webkaos"
 
-ARG WEBKAOS_VER=1.28.2
+ARG WEBKAOS_VER=1.28.3
 ARG REPOSITORY=kaos-release
 
 # hadolint ignore=DL3031,DL3041

--- a/.docker/ol8-unprivileged.docker
+++ b/.docker/ol8-unprivileged.docker
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.title="WEBKAOS (Unprivileged)" \
       org.opencontainers.image.url="https://kaos.sh/webkaos" \
       org.opencontainers.image.source="https://github.com/essentialkaos/webkaos"
 
-ARG WEBKAOS_VER=1.28.2
+ARG WEBKAOS_VER=1.28.3
 ARG REPOSITORY=kaos-release
 
 ARG UID=1001

--- a/.docker/ol8.docker
+++ b/.docker/ol8.docker
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.title="WEBKAOS" \
       org.opencontainers.image.url="https://kaos.sh/webkaos" \
       org.opencontainers.image.source="https://github.com/essentialkaos/webkaos"
 
-ARG WEBKAOS_VER=1.28.2
+ARG WEBKAOS_VER=1.28.3
 ARG REPOSITORY=kaos-release
 
 # hadolint ignore=DL3031,DL3041

--- a/.docker/ol9-unprivileged.docker
+++ b/.docker/ol9-unprivileged.docker
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.title="WEBKAOS (Unprivileged)" \
       org.opencontainers.image.url="https://kaos.sh/webkaos" \
       org.opencontainers.image.source="https://github.com/essentialkaos/webkaos"
 
-ARG WEBKAOS_VER=1.28.2
+ARG WEBKAOS_VER=1.28.3
 ARG REPOSITORY=kaos-release
 
 ARG UID=1001

--- a/.docker/ol9.docker
+++ b/.docker/ol9.docker
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.title="WEBKAOS" \
       org.opencontainers.image.url="https://kaos.sh/webkaos" \
       org.opencontainers.image.source="https://github.com/essentialkaos/webkaos"
 
-ARG WEBKAOS_VER=1.28.2
+ARG WEBKAOS_VER=1.28.3
 ARG REPOSITORY=kaos-release
 
 # hadolint ignore=DL3031,DL3041

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -114,7 +114,7 @@ jobs:
         run: ./.docker/version_check.sh
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
         if: ${{ github.event_name == 'pull_request' && env.DOCKERHUB_USERNAME != '' }}
@@ -123,7 +123,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         if: ${{ github.event_name == 'pull_request' }}
         with:
           registry: ghcr.io

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -37,13 +37,13 @@ jobs:
           fetch-depth: 0
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -149,7 +149,7 @@ jobs:
 
       - name: Build and push Docker images (Docker)
         if: ${{ steps.build_check.outputs.build == 'true' }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           context: .
@@ -160,7 +160,7 @@ jobs:
 
       - name: Build and push Docker images (GHCR)
         if: ${{ steps.build_check.outputs.build == 'true' }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           context: .

--- a/SOURCES/webkaos.patch
+++ b/SOURCES/webkaos.patch
@@ -1,6 +1,6 @@
-diff --color -urN nginx-1.28.2-orig/auto/lib/pcre/make nginx-1.28.2/auto/lib/pcre/make
---- nginx-1.28.2-orig/auto/lib/pcre/make	2026-02-04 20:22:23.000000000 +0300
-+++ nginx-1.28.2/auto/lib/pcre/make	2026-02-05 12:41:01.191347154 +0300
+diff --color -urN nginx-1.28.3-orig/auto/lib/pcre/make nginx-1.28.3/auto/lib/pcre/make
+--- nginx-1.28.3-orig/auto/lib/pcre/make	2026-03-24 21:33:23.000000000 +0300
++++ nginx-1.28.3/auto/lib/pcre/make	2026-05-14 10:04:01.605515018 +0300
 @@ -91,7 +91,7 @@
  $PCRE/Makefile:	$NGX_MAKEFILE
  	cd $PCRE \\
@@ -19,9 +19,9 @@ diff --color -urN nginx-1.28.2-orig/auto/lib/pcre/make nginx-1.28.2/auto/lib/pcr
  	./configure --disable-shared $PCRE_CONF_OPT
  
  $PCRE/.libs/libpcre.a:	$PCRE/Makefile
-diff --color -urN nginx-1.28.2-orig/src/core/nginx.c nginx-1.28.2/src/core/nginx.c
---- nginx-1.28.2-orig/src/core/nginx.c	2026-02-04 20:22:23.000000000 +0300
-+++ nginx-1.28.2/src/core/nginx.c	2026-02-05 12:41:01.199347252 +0300
+diff --color -urN nginx-1.28.3-orig/src/core/nginx.c nginx-1.28.3/src/core/nginx.c
+--- nginx-1.28.3-orig/src/core/nginx.c	2026-03-24 21:33:23.000000000 +0300
++++ nginx-1.28.3/src/core/nginx.c	2026-05-14 10:04:01.611514979 +0300
 @@ -391,12 +391,12 @@
  static void
  ngx_show_version_info(void)
@@ -38,13 +38,13 @@ diff --color -urN nginx-1.28.2-orig/src/core/nginx.c nginx-1.28.2/src/core/nginx
                            NGX_LINEFEED NGX_LINEFEED
              "Options:" NGX_LINEFEED
              "  -?,-h         : this help" NGX_LINEFEED
-diff --color -urN nginx-1.28.2-orig/src/core/nginx.h nginx-1.28.2/src/core/nginx.h
---- nginx-1.28.2-orig/src/core/nginx.h	2026-02-04 20:22:23.000000000 +0300
-+++ nginx-1.28.2/src/core/nginx.h	2026-02-05 12:41:24.000000000 +0300
+diff --color -urN nginx-1.28.3-orig/src/core/nginx.h nginx-1.28.3/src/core/nginx.h
+--- nginx-1.28.3-orig/src/core/nginx.h	2026-03-24 21:33:23.000000000 +0300
++++ nginx-1.28.3/src/core/nginx.h	2026-05-14 10:04:20.000000000 +0300
 @@ -11,7 +11,7 @@
  
- #define nginx_version      1028002
- #define NGINX_VERSION      "1.28.2"
+ #define nginx_version      1028003
+ #define NGINX_VERSION      "1.28.3"
 -#define NGINX_VER          "nginx/" NGINX_VERSION
 +#define NGINX_VER          "webkaos/" NGINX_VERSION
  
@@ -59,9 +59,9 @@ diff --color -urN nginx-1.28.2-orig/src/core/nginx.h nginx-1.28.2/src/core/nginx
  #define NGX_OLDPID_EXT     ".oldbin"
  
  
-diff --color -urN nginx-1.28.2-orig/src/core/ngx_log.c nginx-1.28.2/src/core/ngx_log.c
---- nginx-1.28.2-orig/src/core/ngx_log.c	2026-02-04 20:22:23.000000000 +0300
-+++ nginx-1.28.2/src/core/ngx_log.c	2026-02-05 12:41:01.212347411 +0300
+diff --color -urN nginx-1.28.3-orig/src/core/ngx_log.c nginx-1.28.3/src/core/ngx_log.c
+--- nginx-1.28.3-orig/src/core/ngx_log.c	2026-03-24 21:33:23.000000000 +0300
++++ nginx-1.28.3/src/core/ngx_log.c	2026-05-14 10:04:01.622514908 +0300
 @@ -202,9 +202,9 @@
          return;
      }
@@ -92,9 +92,9 @@ diff --color -urN nginx-1.28.2-orig/src/core/ngx_log.c nginx-1.28.2/src/core/ngx
          return NGX_CONF_ERROR;
  #endif
  
-diff --color -urN nginx-1.28.2-orig/src/http/modules/ngx_http_autoindex_module.c nginx-1.28.2/src/http/modules/ngx_http_autoindex_module.c
---- nginx-1.28.2-orig/src/http/modules/ngx_http_autoindex_module.c	2026-02-04 20:22:23.000000000 +0300
-+++ nginx-1.28.2/src/http/modules/ngx_http_autoindex_module.c	2026-02-05 12:41:01.219347497 +0300
+diff --color -urN nginx-1.28.3-orig/src/http/modules/ngx_http_autoindex_module.c nginx-1.28.3/src/http/modules/ngx_http_autoindex_module.c
+--- nginx-1.28.3-orig/src/http/modules/ngx_http_autoindex_module.c	2026-03-24 21:33:23.000000000 +0300
++++ nginx-1.28.3/src/http/modules/ngx_http_autoindex_module.c	2026-05-14 10:04:01.628514869 +0300
 @@ -449,9 +449,11 @@
      ;
  
@@ -170,9 +170,9 @@ diff --color -urN nginx-1.28.2-orig/src/http/modules/ngx_http_autoindex_module.c
                                tm.ngx_tm_mday,
                                months[tm.ngx_tm_mon - 1],
                                tm.ngx_tm_year,
-diff --color -urN nginx-1.28.2-orig/src/http/ngx_http_header_filter_module.c nginx-1.28.2/src/http/ngx_http_header_filter_module.c
---- nginx-1.28.2-orig/src/http/ngx_http_header_filter_module.c	2026-02-04 20:22:23.000000000 +0300
-+++ nginx-1.28.2/src/http/ngx_http_header_filter_module.c	2026-02-05 12:41:01.225347571 +0300
+diff --color -urN nginx-1.28.3-orig/src/http/ngx_http_header_filter_module.c nginx-1.28.3/src/http/ngx_http_header_filter_module.c
+--- nginx-1.28.3-orig/src/http/ngx_http_header_filter_module.c	2026-03-24 21:33:23.000000000 +0300
++++ nginx-1.28.3/src/http/ngx_http_header_filter_module.c	2026-05-14 10:04:01.635514824 +0300
 @@ -46,7 +46,7 @@
  };
  
@@ -223,9 +223,9 @@ diff --color -urN nginx-1.28.2-orig/src/http/ngx_http_header_filter_module.c ngi
  #define NGX_HTTP_OFF_5XX   (NGX_HTTP_LAST_4XX - 400 + NGX_HTTP_OFF_4XX)
  
      ngx_string("500 Internal Server Error"),
-diff --color -urN nginx-1.28.2-orig/src/http/ngx_http_special_response.c nginx-1.28.2/src/http/ngx_http_special_response.c
---- nginx-1.28.2-orig/src/http/ngx_http_special_response.c	2026-02-04 20:22:23.000000000 +0300
-+++ nginx-1.28.2/src/http/ngx_http_special_response.c	2026-02-05 12:41:01.232347657 +0300
+diff --color -urN nginx-1.28.3-orig/src/http/ngx_http_special_response.c nginx-1.28.3/src/http/ngx_http_special_response.c
+--- nginx-1.28.3-orig/src/http/ngx_http_special_response.c	2026-03-24 21:33:23.000000000 +0300
++++ nginx-1.28.3/src/http/ngx_http_special_response.c	2026-05-14 10:04:01.642514778 +0300
 @@ -19,21 +19,21 @@
  
  
@@ -698,9 +698,9 @@ diff --color -urN nginx-1.28.2-orig/src/http/ngx_http_special_response.c nginx-1
  #define NGX_HTTP_OFF_5XX   (NGX_HTTP_LAST_4XX - 400 + NGX_HTTP_OFF_4XX)
  
      ngx_string(ngx_http_error_494_page), /* 494, request header too large */
-diff --color -urN nginx-1.28.2-orig/src/http/v2/ngx_http_v2_filter_module.c nginx-1.28.2/src/http/v2/ngx_http_v2_filter_module.c
---- nginx-1.28.2-orig/src/http/v2/ngx_http_v2_filter_module.c	2026-02-04 20:22:23.000000000 +0300
-+++ nginx-1.28.2/src/http/v2/ngx_http_v2_filter_module.c	2026-02-05 12:41:01.238347731 +0300
+diff --color -urN nginx-1.28.3-orig/src/http/v2/ngx_http_v2_filter_module.c nginx-1.28.3/src/http/v2/ngx_http_v2_filter_module.c
+--- nginx-1.28.3-orig/src/http/v2/ngx_http_v2_filter_module.c	2026-03-24 21:33:23.000000000 +0300
++++ nginx-1.28.3/src/http/v2/ngx_http_v2_filter_module.c	2026-05-14 10:04:01.649514733 +0300
 @@ -115,7 +115,7 @@
      ngx_http_core_srv_conf_t  *cscf;
      u_char                     addr[NGX_SOCKADDR_STRLEN];
@@ -719,9 +719,9 @@ diff --color -urN nginx-1.28.2-orig/src/http/v2/ngx_http_v2_filter_module.c ngin
          }
  
          *pos++ = ngx_http_v2_inc_indexed(NGX_HTTP_V2_SERVER_INDEX);
-diff --color -urN nginx-1.28.2-orig/src/http/v3/ngx_http_v3_filter_module.c nginx-1.28.2/src/http/v3/ngx_http_v3_filter_module.c
---- nginx-1.28.2-orig/src/http/v3/ngx_http_v3_filter_module.c	2026-02-04 20:22:23.000000000 +0300
-+++ nginx-1.28.2/src/http/v3/ngx_http_v3_filter_module.c	2026-02-05 12:41:01.245347817 +0300
+diff --color -urN nginx-1.28.3-orig/src/http/v3/ngx_http_v3_filter_module.c nginx-1.28.3/src/http/v3/ngx_http_v3_filter_module.c
+--- nginx-1.28.3-orig/src/http/v3/ngx_http_v3_filter_module.c	2026-03-24 21:33:23.000000000 +0300
++++ nginx-1.28.3/src/http/v3/ngx_http_v3_filter_module.c	2026-05-14 10:04:01.656514688 +0300
 @@ -166,7 +166,7 @@
              n = sizeof(NGINX_VER_BUILD) - 1;
  
@@ -742,9 +742,9 @@ diff --color -urN nginx-1.28.2-orig/src/http/v3/ngx_http_v3_filter_module.c ngin
          }
  
          ngx_log_debug2(NGX_LOG_DEBUG_HTTP, c->log, 0,
-diff --color -urN nginx-1.28.2-orig/src/os/unix/ngx_setproctitle.c nginx-1.28.2/src/os/unix/ngx_setproctitle.c
---- nginx-1.28.2-orig/src/os/unix/ngx_setproctitle.c	2026-02-04 20:22:23.000000000 +0300
-+++ nginx-1.28.2/src/os/unix/ngx_setproctitle.c	2026-02-05 12:41:01.251347891 +0300
+diff --color -urN nginx-1.28.3-orig/src/os/unix/ngx_setproctitle.c nginx-1.28.3/src/os/unix/ngx_setproctitle.c
+--- nginx-1.28.3-orig/src/os/unix/ngx_setproctitle.c	2026-03-24 21:33:23.000000000 +0300
++++ nginx-1.28.3/src/os/unix/ngx_setproctitle.c	2026-05-14 10:04:01.662514649 +0300
 @@ -89,7 +89,7 @@
  
      ngx_os_argv[1] = NULL;

--- a/webkaos.spec
+++ b/webkaos.spec
@@ -23,19 +23,19 @@
 %define service_name   %{name}
 %define service_home   %{_cachedir}/%{service_name}
 
-%define nginx_version       1.28.2
+%define nginx_version       1.28.3
 %define lua_module_ver      0.10.29
 %define lua_resty_core_ver  0.1.32
 %define lua_resty_lru_ver   0.15
 %define mh_module_ver       0.39
 %define pcre_ver            10.47
-%define zlib_ver            1.3.1
+%define zlib_ver            1.3.2
 %define luajit_ver          2.1-20250826
 %define luajit_raw_ver      2.1
 
 # 1. Open https://chromiumdash.appspot.com/releases?platform=Linux and note the latest stable version.
 # 2. Open https://chromium.googlesource.com/chromium/src/+/refs/tags/<version>/DEPS and note <boringssl_revision>.
-%define boring_commit  58da9b0d721fd807279f4e3898741c92cf43bdbd
+%define boring_commit  d8be2b4a71155bf82da092ef543176351eeb59ff
 
 ################################################################################
 
@@ -570,8 +570,13 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Thu Feb 05 2026 Anton Novojilov <andy@essentialkaos.com> - 1.28.3-0
+- Nginx updated to 1.28.3
+- zlib updated to 1.3.2
+- BoringSSL updated to the latest stable version for Chromium
+
 * Thu Feb 05 2026 Anton Novojilov <andy@essentialkaos.com> - 1.28.2-0
-- Nginx updated to 1.28.1 with fixes for CVE-2026-1642
+- Nginx updated to 1.28.2 with fixes for CVE-2026-1642
 
 * Wed Jan 14 2026 Anton Novojilov <andy@essentialkaos.com> - 1.28.1-0
 - Nginx updated to 1.28.1 with fixes for CVE-2025-53859


### PR DESCRIPTION
#### Improvements
- Nginx updated to `1.28.3` with fixes for CVE-2026-27654, CVE-2026-27784, CVE-2026-32647, CVE-2026-27651, CVE-2026-28753, and CVE-2026-28755
- zlib updated to `1.3.2`
- BoringSSL updated to the latest stable version for Chromium
